### PR TITLE
TD-1388: rename uploaded files components for clarity

### DIFF
--- a/apps/chat-bot/src/app/api/file-operations/preprocess-image.ts
+++ b/apps/chat-bot/src/app/api/file-operations/preprocess-image.ts
@@ -2,9 +2,9 @@ import { TRUNCATE_IMAGE_HEIGHT } from '@/const';
 import { FileMetadata, FileModel } from '@shared/db/schema';
 import { getFileFromS3, getReadOnlySignedUrl } from '@shared/s3';
 import { isImageFile } from '@/utils/files/generic';
+import { getImageContentType, streamToBase64 } from '@/utils/files/image-data';
 import sharp from 'sharp';
 import { logError } from '@shared/logging';
-import { Readable } from 'stream';
 import { ChatAttachment } from '@ais-chat/ai-core';
 
 export type ChatAttachmentWithMessageId = ChatAttachment & {
@@ -57,12 +57,6 @@ export async function createImageAttachmentsForConversation(
   return images.filter((img) => img !== undefined);
 }
 
-function getImageContentType(type: string): string {
-  if (type === 'jpg') return 'image/jpeg';
-  if (type === 'svg') return 'image/svg+xml';
-  return `image/${type}`;
-}
-
 export async function preprocessImage(
   fileContent: Buffer,
   type: string,
@@ -109,18 +103,6 @@ export async function preprocessImage(
     metadata: { width, height },
     type: processedType,
   };
-}
-
-async function streamToBase64(stream: Readable): Promise<string> {
-  const chunks: Buffer[] = [];
-
-  for await (const chunk of stream) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-  }
-
-  const buffer = Buffer.concat(chunks);
-
-  return buffer.toString('base64');
 }
 
 // returns true if the file has a conversationMessageId which is needed to

--- a/apps/chat-bot/src/app/api/file-operations/scaled-image-service.ts
+++ b/apps/chat-bot/src/app/api/file-operations/scaled-image-service.ts
@@ -31,6 +31,6 @@ export async function createScaledImage({
 
   return {
     buffer,
-    contentType: getImageContentType(metadata.format),
+    contentType: getImageContentType(metadata.format) ?? '',
   };
 }

--- a/apps/chat-bot/src/app/api/file-operations/scaled-image-service.ts
+++ b/apps/chat-bot/src/app/api/file-operations/scaled-image-service.ts
@@ -1,0 +1,36 @@
+import sharp from 'sharp';
+import { getFileFromS3 } from '@shared/s3';
+import { getImageContentType, streamToBuffer } from '@/utils/files/image-data';
+
+const MAX_SCALED_IMAGE_SIZE = 1_000;
+
+export async function createScaledImage({
+  fileId,
+  width,
+  height,
+}: {
+  fileId: string;
+  width?: number;
+  height?: number;
+}): Promise<{ buffer: Buffer; contentType: string }> {
+  const imageStream = await getFileFromS3(`message_attachments/${fileId}`);
+  const imageBuffer = await streamToBuffer(imageStream);
+  const image = sharp(imageBuffer);
+  const metadata = await image.metadata();
+  const resizeOptions = {
+    ...(width !== undefined ? { width: Math.min(width, MAX_SCALED_IMAGE_SIZE) } : {}),
+    ...(height !== undefined ? { height: Math.min(height, MAX_SCALED_IMAGE_SIZE) } : {}),
+    fit: 'inside' as const,
+    withoutEnlargement: true,
+  };
+
+  const buffer =
+    width === undefined && height === undefined
+      ? imageBuffer
+      : await image.resize(resizeOptions).toBuffer();
+
+  return {
+    buffer,
+    contentType: getImageContentType(metadata.format),
+  };
+}

--- a/apps/chat-bot/src/app/api/files/[fileId]/scaled-image/route.ts
+++ b/apps/chat-bot/src/app/api/files/[fileId]/scaled-image/route.ts
@@ -17,16 +17,29 @@ export async function GET(
       return NextResponse.json({ error: 'Not authorized to access this file' }, { status: 403 });
     }
 
+    const widthParam = request.nextUrl.searchParams.get('width');
+    const heightParam = request.nextUrl.searchParams.get('height');
+    const width = widthParam !== null ? Number.parseInt(widthParam, 10) : undefined;
+    const height = heightParam !== null ? Number.parseInt(heightParam, 10) : undefined;
+    if (
+      (width !== undefined && (!Number.isFinite(width) || width <= 0)) ||
+      (height !== undefined && (!Number.isFinite(height) || height <= 0)) ||
+      (width === undefined && height === undefined)
+    ) {
+      return NextResponse.json({ error: 'Invalid width/height' }, { status: 400 });
+    }
+
     const scaledImage = await createScaledImage({
       fileId,
-      width: Number(request.nextUrl.searchParams.get('width')) ?? undefined,
-      height: Number(request.nextUrl.searchParams.get('height')) ?? undefined,
+      width,
+      height,
     });
 
     return new NextResponse(new Uint8Array(scaledImage.buffer), {
       headers: {
         'Cache-Control': 'private, max-age=86400',
         'Content-Type': scaledImage.contentType,
+        'Content-Length': scaledImage.buffer.byteLength.toString(),
       },
     });
   } catch (error) {

--- a/apps/chat-bot/src/app/api/files/[fileId]/scaled-image/route.ts
+++ b/apps/chat-bot/src/app/api/files/[fileId]/scaled-image/route.ts
@@ -1,0 +1,35 @@
+import { getUser } from '@/auth/utils';
+import { handleErrorInRoute } from '@/error/handle-error-in-route';
+import { createScaledImage } from '@/app/api/file-operations/scaled-image-service';
+import { dbVerifyFileOwnership } from '@shared/db/functions/files';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ fileId: string }> },
+) {
+  try {
+    const user = await getUser();
+    const { fileId } = await params;
+    const isOwner = await dbVerifyFileOwnership({ fileId, userId: user.id });
+
+    if (!isOwner) {
+      return NextResponse.json({ error: 'Not authorized to access this file' }, { status: 403 });
+    }
+
+    const scaledImage = await createScaledImage({
+      fileId,
+      width: Number(request.nextUrl.searchParams.get('width')) ?? undefined,
+      height: Number(request.nextUrl.searchParams.get('height')) ?? undefined,
+    });
+
+    return new NextResponse(new Uint8Array(scaledImage.buffer), {
+      headers: {
+        'Cache-Control': 'private, max-age=86400',
+        'Content-Type': scaledImage.contentType,
+      },
+    });
+  } catch (error) {
+    return handleErrorInRoute(error);
+  }
+}

--- a/apps/chat-bot/src/components/chat/chat-box.tsx
+++ b/apps/chat-bot/src/components/chat/chat-box.tsx
@@ -38,7 +38,6 @@ export function ChatBox({
   conversationId,
   characterName,
   status,
-  getSignedUrlFn,
   showWebSourcesInDialog = false,
 }: {
   assistantIcon?: ReactNode;
@@ -53,7 +52,6 @@ export function ChatBox({
   conversationId?: string;
   characterName?: string;
   status: ChatStatus;
-  getSignedUrlFn?: (fileId: string) => Promise<string>;
   showWebSourcesInDialog?: boolean;
 }) {
   const tCommon = useTranslations('common');

--- a/apps/chat-bot/src/components/chat/chat-box.tsx
+++ b/apps/chat-bot/src/components/chat/chat-box.tsx
@@ -105,7 +105,6 @@ export function ChatBox({
                 status="processed"
                 key={file.id}
                 showBanner={false}
-                getSignedUrl={getSignedUrlFn}
               />
             ))}
           </div>

--- a/apps/chat-bot/src/components/chat/chat-box.tsx
+++ b/apps/chat-bot/src/components/chat/chat-box.tsx
@@ -1,6 +1,6 @@
 import { FileModel } from '@shared/db/schema';
-import DisplayUploadedFile from './display-uploaded-file';
-import DisplayUploadedImage, { type PendingFileModel } from './display-uploaded-image';
+import MessageFileAttachment from './message-file-attachment';
+import MessageImageAttachment, { type PendingFileModel } from './message-image-attachment';
 import CopyToClipboardButton from '../common/clipboard-button';
 import ReloadIcon from '../icons/reload';
 import MarkdownDisplay from './markdown-display';
@@ -98,7 +98,7 @@ export function ChatBox({
         {imageFiles.length > 0 && (
           <div className="flex flex-row gap-2 overflow-auto">
             {imageFiles.map((file) => (
-              <DisplayUploadedImage
+              <MessageImageAttachment
                 file={file}
                 status="processed"
                 key={file.id}
@@ -111,7 +111,7 @@ export function ChatBox({
         {nonImageFiles.length > 0 && (
           <div className="flex w-fit max-w-full min-w-0 flex-row flex-wrap justify-end gap-2 overflow-hidden">
             {nonImageFiles.map((file) => (
-              <DisplayUploadedFile fileName={file.name} status="processed" key={file.id} />
+              <MessageFileAttachment fileName={file.name} key={file.id} />
             ))}
           </div>
         )}

--- a/apps/chat-bot/src/components/chat/chat-input-attachment-preview.tsx
+++ b/apps/chat-bot/src/components/chat/chat-input-attachment-preview.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { FileStatus } from './upload-file-button';
-
 import { getFileIconByFileExtension } from '../icons/file-upload-icons/file-icons-dict';
 import DeattachFileIcon from '../icons/file-upload-icons/deattach-file-icon';
 import Spinner from '../icons/spinner';
@@ -9,44 +7,34 @@ import { getFileNameAndFileExtension, isImageFile } from '@/utils/files/generic'
 import { LocalFileState } from './send-message-form';
 import { cn } from '@/utils/tailwind';
 
-type DisplayUploadedFileProps = {
-  fileName: string;
-  status: FileStatus;
-  file?: LocalFileState;
+type ChatInputAttachmentPreviewProps = {
+  file: LocalFileState;
   onDeattachFile?: () => void;
   height?: 'default' | 'large';
   width?: 'default' | 'small';
 };
 
-export default function DisplayUploadedFile({
-  fileName,
-  status,
+export default function ChatInputAttachmentPreview({
   file,
   onDeattachFile,
   height = 'default',
   width = 'default',
-}: DisplayUploadedFileProps) {
+}: ChatInputAttachmentPreviewProps) {
+  const fileName = file.file.name;
   const [fileStem, fileExtension] = getFileNameAndFileExtension(fileName);
   const isImage = isImageFile(fileName);
   const [imageUrl, setImageUrl] = React.useState<string>();
-
   const { Icon: FileIcon, fillColor: backgroundColor } = getFileIconByFileExtension(fileExtension);
-
   React.useEffect(() => {
-    if (!isImage || file === undefined) {
-      return;
-    }
-
+    if (!isImage) return;
     const objectUrl = URL.createObjectURL(file.file);
     const animationFrame = requestAnimationFrame(() => setImageUrl(objectUrl));
-
     return () => {
       cancelAnimationFrame(animationFrame);
       URL.revokeObjectURL(objectUrl);
     };
   }, [file, isImage]);
-
-  if (isImage && file) {
+  if (isImage)
     return (
       <div className="flex items-center justify-center text-sm relative group">
         <div
@@ -62,10 +50,13 @@ export default function DisplayUploadedFile({
           </button>
         )}
         <div className="relative flex items-center gap-2 h-14 w-14 overflow-hidden rounded-enterprise-sm">
-          {status !== 'failed' && imageUrl !== undefined ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img src={imageUrl} alt={fileName} className="w-full h-full object-cover" />
-          ) : status === 'uploading' ? (
+          {file.status !== 'failed' && imageUrl !== undefined ? (
+            <>
+              <span className="sr-only">{fileName}</span>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={imageUrl} alt={fileName} className="w-full h-full object-cover" />
+            </>
+          ) : file.status === 'uploading' ? (
             <Spinner className="w-14 h-5" />
           ) : (
             <CrossIcon className="w-5 h-5" />
@@ -73,8 +64,6 @@ export default function DisplayUploadedFile({
         </div>
       </div>
     );
-  }
-
   return (
     <div
       className={cn(
@@ -94,11 +83,11 @@ export default function DisplayUploadedFile({
           height === 'large' ? 'h-14' : 'h-6',
         )}
       >
-        {status === 'processed' && (
+        {file.status === 'processed' && (
           <FileIcon className="h-5 w-5 shrink-0" color={backgroundColor} />
         )}
-        {status === 'uploading' && <Spinner className="h-5 w-5 shrink-0" />}
-        {status === 'failed' && <CrossIcon className="h-5 w-5 shrink-0" />}
+        {file.status === 'uploading' && <Spinner className="h-5 w-5 shrink-0" />}
+        {file.status === 'failed' && <CrossIcon className="h-5 w-5 shrink-0" />}
         <div className={cn('flex min-w-0 flex-col', width === 'small' ? 'max-w-24' : 'max-w-80')}>
           <p className="truncate overflow-hidden text-sm" title={fileName}>
             {fileStem}

--- a/apps/chat-bot/src/components/chat/chat-input-box.tsx
+++ b/apps/chat-bot/src/components/chat/chat-input-box.tsx
@@ -37,7 +37,6 @@ export function ChatInputBox({
   input,
   enableFileUpload = false,
   fileUploadFn,
-  getSignedUrlFn,
   showPlaceholder = true,
 }: {
   files?: Map<string, LocalFileState>;
@@ -50,7 +49,6 @@ export function ChatInputBox({
   input: string;
   enableFileUpload?: boolean;
   fileUploadFn?: (file: File) => Promise<FileUploadResponse>;
-  getSignedUrlFn?: (fileId: string) => Promise<string>;
   showPlaceholder?: boolean;
 }) {
   const tCommon = useTranslations('common');
@@ -153,7 +151,6 @@ export function ChatInputBox({
                 status={file.status}
                 file={file}
                 onDeattachFile={() => handleDeattachFile(localId)}
-                getSignedUrl={getSignedUrlFn}
                 height="large"
                 width="small"
               />

--- a/apps/chat-bot/src/components/chat/chat-input-box.tsx
+++ b/apps/chat-bot/src/components/chat/chat-input-box.tsx
@@ -1,6 +1,6 @@
 import { useTranslations } from 'next-intl';
 import AutoResizeTextarea from '../common/auto-resize-textarea';
-import DisplayUploadedFile from './display-uploaded-file';
+import ChatInputAttachmentPreview from './chat-input-attachment-preview';
 import { LocalFileState } from './send-message-form';
 import {
   CHAT_MESSAGE_LENGTH_LIMIT,
@@ -145,10 +145,8 @@ export function ChatInputBox({
         {files !== undefined && handleDeattachFile !== undefined && files.size > 0 && (
           <div className="mx-2 py-2 flex gap-1 overflow-x-auto">
             {Array.from(files).map(([localId, file]) => (
-              <DisplayUploadedFile
-                fileName={file.file.name}
+              <ChatInputAttachmentPreview
                 key={localId}
-                status={file.status}
                 file={file}
                 onDeattachFile={() => handleDeattachFile(localId)}
                 height="large"

--- a/apps/chat-bot/src/components/chat/display-uploaded-file.tsx
+++ b/apps/chat-bot/src/components/chat/display-uploaded-file.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Image from 'next/image';
 import { FileStatus } from './upload-file-button';
 
 import { getFileIconByFileExtension } from '../icons/file-upload-icons/file-icons-dict';
@@ -7,8 +6,6 @@ import DeattachFileIcon from '../icons/file-upload-icons/deattach-file-icon';
 import Spinner from '../icons/spinner';
 import CrossIcon from '../icons/cross';
 import { getFileNameAndFileExtension, isImageFile } from '@/utils/files/generic';
-import { getReadOnlySignedUrlAction } from '@/app/api/file-operations/actions';
-import { useQuery } from '@tanstack/react-query';
 import { LocalFileState } from './send-message-form';
 import { cn } from '@/utils/tailwind';
 
@@ -17,7 +14,6 @@ type DisplayUploadedFileProps = {
   status: FileStatus;
   file?: LocalFileState;
   onDeattachFile?: () => void;
-  getSignedUrl?: (fileId: string) => Promise<string>;
   height?: 'default' | 'large';
   width?: 'default' | 'small';
 };
@@ -27,37 +23,29 @@ export default function DisplayUploadedFile({
   status,
   file,
   onDeattachFile,
-  getSignedUrl,
   height = 'default',
   width = 'default',
 }: DisplayUploadedFileProps) {
   const [fileStem, fileExtension] = getFileNameAndFileExtension(fileName);
   const isImage = isImageFile(fileName);
+  const [imageUrl, setImageUrl] = React.useState<string>();
 
   const { Icon: FileIcon, fillColor: backgroundColor } = getFileIconByFileExtension(fileExtension);
 
-  const { data: imageUrl, isLoading } = useQuery({
-    queryKey: file
-      ? ['signed-url', file.fileId, file.file.name, file.file.type]
-      : ['signed-url', null, null, null],
-    queryFn: async () => {
-      if (!file) {
-        throw new Error('File is undefined');
-      }
+  React.useEffect(() => {
+    if (!isImage || file === undefined) {
+      return;
+    }
 
-      if (getSignedUrl !== undefined && file.fileId !== undefined) {
-        return getSignedUrl(file.fileId);
-      }
+    const objectUrl = URL.createObjectURL(file.file);
+    const animationFrame = requestAnimationFrame(() => setImageUrl(objectUrl));
 
-      const signedUrl = await getReadOnlySignedUrlAction({
-        key: `message_attachments/${file.fileId}`,
-      });
-      return signedUrl;
-    },
-    enabled: status === 'processed' && file?.fileId !== undefined, // Only fetch when status is processed and a fileId exists
-    staleTime: 5 * 60 * 1000, // 5 minutes - signed URLs are typically valid for longer
-    gcTime: 10 * 60 * 1000, // 10 minutes garbage collection time
-  });
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      URL.revokeObjectURL(objectUrl);
+    };
+  }, [file, isImage]);
+
   if (isImage && file) {
     return (
       <div className="flex items-center justify-center text-sm relative group">
@@ -74,17 +62,10 @@ export default function DisplayUploadedFile({
           </button>
         )}
         <div className="relative flex items-center gap-2 h-14 w-14 overflow-hidden rounded-enterprise-sm">
-          {status === 'processed' && !isLoading && !!imageUrl ? (
-            <Image
-              src={imageUrl}
-              alt={fileName}
-              width={200}
-              height={200}
-              loading="eager"
-              className="w-full h-full object-cover"
-              unoptimized // Since we're using signed URLs from S3
-            />
-          ) : status === 'uploading' || isLoading ? (
+          {status !== 'failed' && imageUrl !== undefined ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={imageUrl} alt={fileName} className="w-full h-full object-cover" />
+          ) : status === 'uploading' ? (
             <Spinner className="w-14 h-5" />
           ) : (
             <CrossIcon className="w-5 h-5" />

--- a/apps/chat-bot/src/components/chat/display-uploaded-image.tsx
+++ b/apps/chat-bot/src/components/chat/display-uploaded-image.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import Image from 'next/image';
-import { useQuery } from '@tanstack/react-query';
 import { FileModel } from '@shared/db/schema';
 import { FileStatus } from './upload-file-button';
 import DeattachFileIcon from '../icons/file-upload-icons/deattach-file-icon';
 import Spinner from '../icons/spinner';
 import CrossIcon from '../icons/cross';
-import { EmptyImageIcon } from '../icons/empty-image';
-import { cn } from '@/utils/tailwind';
 import { useTranslations } from 'next-intl';
 
 // Extended type for pending files that includes a local blob URL
@@ -30,20 +27,10 @@ export default function DisplayUploadedImage({
 
   // Check if file has a local URL (for pending files)
   const localUrl = 'localUrl' in file ? file.localUrl : undefined;
-  const {
-    data: fetchedImageUrl,
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: ['scaled-image-url', file.id, file.name, file.type],
-    queryFn: async () => {
-      return `/api/files/${file.id}/scaled-image?width=200&height=200`;
-    },
-    // Don't fetch if we have a local URL or status is not processed
-    enabled: status === 'processed' && !localUrl,
-    staleTime: Infinity,
-    gcTime: 24 * 60 * 60 * 1000, // 24 hours garbage collection time
-  });
+  const fetchedImageUrl =
+    status === 'processed' && !localUrl
+      ? `/api/files/${file.id}/scaled-image?width=200&height=200`
+      : null;
 
   // Use local URL if available, otherwise use signed URL from S3
   const imageUrl = localUrl ?? fetchedImageUrl;
@@ -56,16 +43,8 @@ export default function DisplayUploadedImage({
       </div>
     );
   }
-  // Only show loading if we don't have a local URL and are fetching signed URL
-  if (isLoading && !localUrl) {
-    return (
-      <div className="flex items-center justify-center gap-2 text-sm relative group py-4 pr-6 pl-4 shrink-0 max-w-[250px] min-w-[100px] bg-gray-50 rounded-lg">
-        <EmptyImageIcon className={cn(`w-[200px]`, 'text-gray-300 animate-pulse')} />
-      </div>
-    );
-  }
 
-  if ((error && !localUrl) || !imageUrl) {
+  if (!imageUrl) {
     return (
       <div className="flex items-center justify-center gap-2 text-sm relative group py-4 pr-6 pl-4 shrink-0 max-w-[250px] min-w-[100px] bg-red-50 rounded-lg">
         <CrossIcon className="w-5 h-5 text-red-500" />

--- a/apps/chat-bot/src/components/chat/display-uploaded-image.tsx
+++ b/apps/chat-bot/src/components/chat/display-uploaded-image.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Image from 'next/image';
 import { useQuery } from '@tanstack/react-query';
 import { FileModel } from '@shared/db/schema';
-import { getReadOnlySignedUrlAction } from '@/app/api/file-operations/actions';
 import { FileStatus } from './upload-file-button';
 import DeattachFileIcon from '../icons/file-upload-icons/deattach-file-icon';
 import Spinner from '../icons/spinner';
@@ -19,7 +18,6 @@ type DisplayUploadedImageProps = {
   status: FileStatus;
   onDeattachFile?: () => void;
   showBanner?: boolean;
-  getSignedUrl?: (fileId: string) => Promise<string>;
 };
 
 export default function DisplayUploadedImage({
@@ -27,37 +25,28 @@ export default function DisplayUploadedImage({
   status,
   onDeattachFile,
   showBanner = true,
-  getSignedUrl,
 }: DisplayUploadedImageProps) {
   const t = useTranslations();
 
   // Check if file has a local URL (for pending files)
   const localUrl = 'localUrl' in file ? file.localUrl : undefined;
-
   const {
-    data: signedUrl,
+    data: fetchedImageUrl,
     isLoading,
     error,
   } = useQuery({
-    queryKey: ['signed-url', file.id, file.name, file.type],
+    queryKey: ['scaled-image-url', file.id, file.name, file.type],
     queryFn: async () => {
-      if (getSignedUrl !== undefined) {
-        return getSignedUrl(file.id);
-      }
-
-      const signedUrl = await getReadOnlySignedUrlAction({
-        key: `message_attachments/${file.id}`,
-      });
-      return signedUrl;
+      return `/api/files/${file.id}/scaled-image?width=200&height=200`;
     },
     // Don't fetch if we have a local URL or status is not processed
     enabled: status === 'processed' && !localUrl,
-    staleTime: 5 * 60 * 1000, // 5 minutes - signed URLs are typically valid for longer
-    gcTime: 10 * 60 * 1000, // 10 minutes garbage collection time
+    staleTime: Infinity,
+    gcTime: 24 * 60 * 60 * 1000, // 24 hours garbage collection time
   });
 
   // Use local URL if available, otherwise use signed URL from S3
-  const imageUrl = localUrl ?? signedUrl;
+  const imageUrl = localUrl ?? fetchedImageUrl;
 
   if (status === 'uploading') {
     return (

--- a/apps/chat-bot/src/components/chat/display-uploaded-image.tsx
+++ b/apps/chat-bot/src/components/chat/display-uploaded-image.tsx
@@ -10,19 +10,19 @@ import { useTranslations } from 'next-intl';
 // Extended type for pending files that includes a local blob URL
 export type PendingFileModel = FileModel & { localUrl?: string };
 
-type DisplayUploadedImageProps = {
+type MessageImageAttachmentProps = {
   file: FileModel | PendingFileModel;
   status: FileStatus;
   onDeattachFile?: () => void;
   showBanner?: boolean;
 };
 
-export default function DisplayUploadedImage({
+export default function MessageImageAttachment({
   file,
   status,
   onDeattachFile,
   showBanner = true,
-}: DisplayUploadedImageProps) {
+}: MessageImageAttachmentProps) {
   const t = useTranslations();
 
   // Check if file has a local URL (for pending files)

--- a/apps/chat-bot/src/components/chat/message-file-attachment.tsx
+++ b/apps/chat-bot/src/components/chat/message-file-attachment.tsx
@@ -1,0 +1,20 @@
+import { getFileIconByFileExtension } from '../icons/file-upload-icons/file-icons-dict';
+import { getFileNameAndFileExtension } from '@/utils/files/generic';
+
+export default function MessageFileAttachment({ fileName }: { fileName: string }) {
+  const [fileStem, fileExtension] = getFileNameAndFileExtension(fileName);
+  const { Icon: FileIcon, fillColor: backgroundColor } = getFileIconByFileExtension(fileExtension);
+  return (
+    <div className="flex w-fit min-w-0 max-w-full shrink-0 items-center justify-start gap-2 py-2 pl-4 pr-6 text-sm relative group">
+      <div className="absolute inset-0 opacity-5 rounded-lg" style={{ backgroundColor }} />
+      <div className="relative flex h-6 min-w-0 items-center gap-2">
+        <FileIcon className="h-5 w-5 shrink-0" color={backgroundColor} />
+        <div className="flex min-w-0 flex-col max-w-80">
+          <p className="truncate overflow-hidden text-sm" title={fileName}>
+            {fileStem}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/chat-bot/src/components/chat/message-image-attachment.tsx
+++ b/apps/chat-bot/src/components/chat/message-image-attachment.tsx
@@ -1,0 +1,2 @@
+export { default } from './display-uploaded-image';
+export type { PendingFileModel } from './display-uploaded-image';

--- a/apps/chat-bot/src/components/chat/messages.tsx
+++ b/apps/chat-bot/src/components/chat/messages.tsx
@@ -18,7 +18,6 @@ interface MessagesProps {
   fileMapping?: Map<string, FileModel[]>;
   pendingFileMapping?: Map<string, PendingFileModel[]>;
   webSourceMapping?: Map<string, WebSource[]>;
-  getSignedUrlFn?: (fileId: string) => Promise<string>;
   showWebSourcesInDialog?: boolean;
 }
 
@@ -33,7 +32,6 @@ export function Messages({
   fileMapping,
   pendingFileMapping,
   webSourceMapping,
-  getSignedUrlFn,
   showWebSourcesInDialog,
 }: MessagesProps) {
   return (
@@ -51,7 +49,6 @@ export function Messages({
           assistantIcon={assistantIcon}
           webSources={message.role === 'user' ? webSourceMapping?.get(message.id) : undefined}
           status={status}
-          getSignedUrlFn={getSignedUrlFn}
           showWebSourcesInDialog={showWebSourcesInDialog}
         >
           {message}

--- a/apps/chat-bot/src/components/shared-chat/character-shared-chat.tsx
+++ b/apps/chat-bot/src/components/shared-chat/character-shared-chat.tsx
@@ -72,34 +72,6 @@ export default function CharacterSharedChat({
     };
   }
 
-  async function getSignedUrlForSharedCharacterFile(
-    fileId: string,
-    sharedSessionId: string,
-  ): Promise<string> {
-    const response = await fetch('/api/v1/shared-chat/files/signed-url', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        inviteCode,
-        entityType: 'character',
-        entityId: id,
-        fileId,
-        sharedSessionId,
-      }),
-    });
-
-    if (!response.ok) {
-      throw new Error('Could not read file');
-    }
-
-    const json = await response.json();
-    const parsed = z.object({ signedUrl: z.string() }).parse(json);
-
-    return parsed.signedUrl;
-  }
-
   return (
     <GenericSharedChat
       headerT={t}
@@ -110,7 +82,6 @@ export default function CharacterSharedChat({
       dialogStartMode="derived"
       assistantIcon={assistantIcon}
       uploadFileFn={uploadSharedCharacterFile}
-      getSignedUrlFn={getSignedUrlForSharedCharacterFile}
       showWebSourcesInDialog
     />
   );

--- a/apps/chat-bot/src/components/shared-chat/generic-shared-chat.tsx
+++ b/apps/chat-bot/src/components/shared-chat/generic-shared-chat.tsx
@@ -87,7 +87,6 @@ export type SharedChatViewProps = {
    */
   assistantIcon?: ReactNode;
   uploadFileFn?: (file: File, sharedSessionId: string) => Promise<{ fileId: string }>;
-  getSignedUrlFn?: (fileId: string, sharedSessionId: string) => Promise<string>;
   /**
    * When true, web search results are shown in a modal dialog
    * triggered from the message icons row instead of the inline panel above
@@ -115,7 +114,6 @@ export default function GenericSharedChat({
   enableFloatingText = false,
   assistantIcon,
   uploadFileFn,
-  getSignedUrlFn,
   showWebSourcesInDialog,
 }: SharedChatViewProps) {
   const tCommon = useTranslations('common');
@@ -367,11 +365,6 @@ export default function GenericSharedChat({
                 assistantIcon={assistantIcon}
                 containerClassName="flex flex-col gap-4"
                 pendingFileMapping={pendingFileMapping}
-                getSignedUrlFn={
-                  getSignedUrlFn === undefined
-                    ? undefined
-                    : (fileId) => getSignedUrlFn(fileId, sharedSessionId)
-                }
                 showWebSourcesInDialog={showWebSourcesInDialog}
               />
             )}
@@ -399,11 +392,6 @@ export default function GenericSharedChat({
                     uploadFileFn === undefined
                       ? undefined
                       : (file) => uploadFileFn(file, sharedSessionId)
-                  }
-                  getSignedUrlFn={
-                    getSignedUrlFn === undefined
-                      ? undefined
-                      : (fileId) => getSignedUrlFn(fileId, sharedSessionId)
                   }
                   handleDeattachFile={handleDeattachFile}
                   showPlaceholder={false}

--- a/apps/chat-bot/src/components/shared-chat/learning-scenario-shared-chat.tsx
+++ b/apps/chat-bot/src/components/shared-chat/learning-scenario-shared-chat.tsx
@@ -56,34 +56,6 @@ export default function LearningScenarioSharedChat({
     };
   }
 
-  async function getSignedUrlForSharedLearningScenarioFile(
-    fileId: string,
-    sharedSessionId: string,
-  ): Promise<string> {
-    const response = await fetch('/api/v1/shared-chat/files/signed-url', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        inviteCode,
-        entityType: 'learningScenario',
-        entityId: id,
-        fileId,
-        sharedSessionId,
-      }),
-    });
-
-    if (!response.ok) {
-      throw new Error('Could not read file');
-    }
-
-    const json = await response.json();
-    const parsed = z.object({ signedUrl: z.string() }).parse(json);
-
-    return parsed.signedUrl;
-  }
-
   return (
     <GenericSharedChat
       headerT={t}
@@ -96,7 +68,6 @@ export default function LearningScenarioSharedChat({
       exerciseDescription={sharedSchoolChat.studentExercise}
       exerciseTitle={t('exercise-title')}
       uploadFileFn={uploadSharedLearningScenarioFile}
-      getSignedUrlFn={getSignedUrlForSharedLearningScenarioFile}
     />
   );
 }

--- a/apps/chat-bot/src/utils/files/image-data.ts
+++ b/apps/chat-bot/src/utils/files/image-data.ts
@@ -1,0 +1,40 @@
+export function getImageContentType(type: string): string {
+  switch (type.toLowerCase()) {
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg';
+    case 'svg':
+      return 'image/svg+xml';
+    case 'png':
+      return 'image/png';
+    case 'webp':
+      return 'image/webp';
+    case 'gif':
+      return 'image/gif';
+    case 'avif':
+      return 'image/avif';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+export async function streamToBase64(stream: NodeJS.ReadableStream): Promise<string> {
+  const buffer = await streamToBuffer(stream);
+  return buffer.toString('base64');
+}
+
+export async function streamToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of stream) {
+    chunks.push(
+      Buffer.isBuffer(chunk)
+        ? chunk
+        : typeof chunk === 'string'
+          ? Buffer.from(chunk)
+          : Buffer.from(chunk as Uint8Array),
+    );
+  }
+
+  return Buffer.concat(chunks);
+}


### PR DESCRIPTION
The naming of the uploaded files/images components was confusing, because `DisplayUploadedImage` was used for image files **only** and **only** in the chat history whereas `DisplayUploadedFiles` was used for both images **and** non-image files in the preview but for non-image files **only** in the chat history

Before:
<img width="514" height="131" alt="image" src="https://github.com/user-attachments/assets/6deb7544-7e6c-4bdb-8bb7-df96512404a8" />

After:
<img width="568" height="102" alt="image" src="https://github.com/user-attachments/assets/4a144444-9c85-4e28-99a5-dbdc5459d207" />
