### PR TITLE
TD-1498: duplicate assistant/character avatars on template creation

### DIFF
--- a/apps/chat-bot/src/startup.ts
+++ b/apps/chat-bot/src/startup.ts
@@ -28,7 +28,9 @@ async function postMigration() {
   await tempAddApiKeyIdsToFederalStates();
   await tempAddPictureUrlsToFederalStates();
   // run fix in the background
-  void tempFixInvalidPictureIds();
+  void tempFixInvalidPictureIds().catch((error) =>
+    logError('Failed to run picture id migration', error),
+  );
 }
 
 /**

--- a/apps/chat-bot/src/startup.ts
+++ b/apps/chat-bot/src/startup.ts
@@ -7,6 +7,7 @@ import { lookupApiKeys } from '@ais-chat/ai-core/api-keys/lookup';
 import { logError, logInfo } from '@shared/logging';
 import { listFilesFromS3 } from '@shared/s3';
 import { registerCleanupHandler } from '@shared/shutdown/cleanup';
+import { fixInvalidPictureIds } from '@shared/templates/fix-invalid-picture-ids';
 import { shutdownRabbitMQ } from '@/rabbitmq/send';
 
 /**
@@ -26,6 +27,8 @@ export async function startup() {
 async function postMigration() {
   await tempAddApiKeyIdsToFederalStates();
   await tempAddPictureUrlsToFederalStates();
+  // run fix in the background
+  void tempFixInvalidPictureIds();
 }
 
 /**
@@ -122,4 +125,15 @@ async function tempAddPictureUrlsToFederalStates() {
   }
 
   logInfo(`Completed picture URL updates for ${statesToUpdate.length} federal states`);
+}
+
+/**
+ * Temporary migration that fixes assistants/characters whose picture id still references
+ * another entity's S3 object instead of their own (a leftover of missing avatar duplication
+ * on template/duplicate creation).
+ *
+ * TODO: delete after executing in production once
+ */
+async function tempFixInvalidPictureIds() {
+  await fixInvalidPictureIds();
 }

--- a/packages/shared/src/assistants/assistant-service.test.ts
+++ b/packages/shared/src/assistants/assistant-service.test.ts
@@ -34,11 +34,7 @@ import {
 } from '@shared/conversation/conversation-service';
 import { uploadFileToS3 } from '../s3';
 import { getAvatarPictureUrl } from '../files/fileService';
-import {
-  copyAssistant,
-  copyEntityPictureIfExists,
-  copyRelatedTemplateFiles,
-} from '../templates/template-service';
+import { copyAssistant, copyRelatedTemplateFiles } from '../templates/template-service';
 
 vi.mock('../db/functions/assistants', () => ({
   dbGetAssistantsByUserId: vi.fn(),
@@ -68,7 +64,6 @@ vi.mock('../files/fileService', () => ({
 vi.mock('../templates/template-service', () => ({
   copyAssistant: vi.fn(),
   copyRelatedTemplateFiles: vi.fn(),
-  copyEntityPictureIfExists: vi.fn(),
 }));
 const { mockDbReturning, mockDbSet, mockDbUpdate } = vi.hoisted(() => {
   const mockDbReturning = vi.fn();
@@ -553,9 +548,6 @@ describe('assistant-service', () => {
       (copyAssistant as MockedFunction<typeof copyAssistant>).mockResolvedValue(
         insertedAssistant as never,
       );
-      (
-        copyEntityPictureIfExists as MockedFunction<typeof copyEntityPictureIfExists>
-      ).mockResolvedValue(undefined as never);
 
       const result = await createNewAssistant({
         templateId,
@@ -569,11 +561,6 @@ describe('assistant-service', () => {
         expect.objectContaining({ id: expect.any(String) }),
         duplicatedAssistantName,
       );
-      expect(copyEntityPictureIfExists).toHaveBeenCalledWith({
-        sourcePictureId: null,
-        newEntityId: insertedAssistant.id,
-        buildPictureKey: expect.any(Function),
-      });
       expect(copyRelatedTemplateFiles).toHaveBeenCalledWith(
         'assistant',
         templateId,
@@ -596,9 +583,6 @@ describe('assistant-service', () => {
       (copyAssistant as MockedFunction<typeof copyAssistant>).mockResolvedValue(
         insertedAssistant as never,
       );
-      (
-        copyEntityPictureIfExists as MockedFunction<typeof copyEntityPictureIfExists>
-      ).mockResolvedValue(undefined as never);
 
       await createNewAssistant({
         templateId,
@@ -613,67 +597,25 @@ describe('assistant-service', () => {
       );
     });
 
-    it('should update assistant picture when template picture is copied', async () => {
-      const insertedAssistant = {
-        id: generateUUID(),
-        pictureId: 'custom-gpts/template-id/original.png',
-      } as AssistantSelectModel;
-      const copiedPictureKey = `custom-gpts/${insertedAssistant.id}/original.png`;
-      const updatedAssistant = {
-        ...insertedAssistant,
-        pictureId: copiedPictureKey,
-      } as AssistantSelectModel;
-      const user = mockUser('teacher');
-
-      (dbGetAssistantById as MockedFunction<typeof dbGetAssistantById>).mockResolvedValue(
-        templateAssistant({ userId: user.id, accessLevel: 'private' }) as never,
-      );
-
-      (copyAssistant as MockedFunction<typeof copyAssistant>).mockResolvedValue(
-        insertedAssistant as never,
-      );
-      (
-        copyEntityPictureIfExists as MockedFunction<typeof copyEntityPictureIfExists>
-      ).mockResolvedValue(copiedPictureKey as never);
-      mockDbReturning.mockResolvedValue([updatedAssistant]);
-
-      const result = await createNewAssistant({
-        templateId,
-        user,
-      });
-
-      expect(copyEntityPictureIfExists).toHaveBeenCalledWith({
-        sourcePictureId: insertedAssistant.pictureId,
-        newEntityId: insertedAssistant.id,
-        buildPictureKey: expect.any(Function),
-      });
-      expect(result).toEqual({ ...updatedAssistant, ownerSchoolIds: user.schoolIds });
-    });
-
-    it('should keep assistant unchanged when no copied picture key is returned', async () => {
+    it('should return the assistant from copyAssistant as-is, without copying its picture again', async () => {
       const user = mockUser('teacher');
       const insertedAssistant = {
         id: generateUUID(),
-        pictureId: 'custom-gpts/template-id/original.png',
+        pictureId: 'custom-gpts/already-scoped-id/avatar_abc123',
       } as AssistantSelectModel;
 
       (dbGetAssistantById as MockedFunction<typeof dbGetAssistantById>).mockResolvedValue(
         templateAssistant({ userId: user.id, accessLevel: 'private' }) as never,
       );
-
       (copyAssistant as MockedFunction<typeof copyAssistant>).mockResolvedValue(
         insertedAssistant as never,
       );
-      (
-        copyEntityPictureIfExists as MockedFunction<typeof copyEntityPictureIfExists>
-      ).mockResolvedValue(undefined as never);
 
-      const result = await createNewAssistant({
-        templateId,
-        user,
-      });
+      const result = await createNewAssistant({ templateId, user });
 
-      expect(result).toEqual(insertedAssistant);
+      // copyAssistant already duplicates the picture; createNewAssistant must not attempt to
+      // copy it again (which would be a no-op S3 self-copy at best, an error at worst).
+      expect(result).toBe(insertedAssistant);
     });
 
     it('should throw ForbiddenError when template is suspended', async () => {

--- a/packages/shared/src/assistants/assistant-service.ts
+++ b/packages/shared/src/assistants/assistant-service.ts
@@ -34,11 +34,7 @@ import {
 import { buildAssistantPictureKey } from '@shared/utils/picture-key';
 import { deleteFileFromS3, getReadOnlySignedUrl, uploadFileToS3 } from '@shared/s3';
 import { ONE_HOUR } from '@shared/s3/const';
-import {
-  copyAssistant,
-  copyEntityPictureIfExists,
-  copyRelatedTemplateFiles,
-} from '@shared/templates/template-service';
+import { copyAssistant, copyRelatedTemplateFiles } from '@shared/templates/template-service';
 import { OverviewFilter } from '@shared/overview-filter';
 import { generateUUID } from '@shared/utils/uuid';
 import {
@@ -264,31 +260,12 @@ export async function createNewAssistant({
     });
     verifySuspensionState({ item: sourceAssistant });
 
-    let insertedAssistant = await copyAssistant(
+    const insertedAssistant = await copyAssistant(
       templateId,
       'private',
       user,
       duplicateAssistantName,
     );
-
-    const copyOfTemplatePicture = await copyEntityPictureIfExists({
-      sourcePictureId: insertedAssistant.pictureId,
-      newEntityId: insertedAssistant.id,
-      buildPictureKey: buildAssistantPictureKey,
-    });
-
-    if (copyOfTemplatePicture) {
-      // Update the assistant with the new picture
-      const [updatedAssistant] = await db
-        .update(assistantTable)
-        .set({ pictureId: copyOfTemplatePicture })
-        .where(eq(assistantTable.id, insertedAssistant.id))
-        .returning();
-
-      if (updatedAssistant) {
-        insertedAssistant = { ...updatedAssistant, ownerSchoolIds: user.schoolIds };
-      }
-    }
 
     await copyRelatedTemplateFiles('assistant', templateId, insertedAssistant.id);
     return insertedAssistant;

--- a/packages/shared/src/characters/character-service.test.ts
+++ b/packages/shared/src/characters/character-service.test.ts
@@ -46,11 +46,7 @@ import { SHARE_EXTENSION_WINDOW_MS } from '../sharing/const';
 import { FederalStateModel } from '@shared/federal-states/types';
 import { ForbiddenError, InvalidArgumentError, NotFoundError } from '@shared/error';
 import { dbGetSharedCharacterChatUsageInCentByCharacterId } from '@shared/db/functions/token-points';
-import {
-  copyCharacter,
-  copyEntityPictureIfExists,
-  copyRelatedTemplateFiles,
-} from '../templates/template-service';
+import { copyCharacter, copyRelatedTemplateFiles } from '../templates/template-service';
 
 vi.mock('../db/functions/character', () => ({
   dbGetAllAccessibleCharacters: vi.fn(),
@@ -89,7 +85,6 @@ vi.mock('../files/fileService', () => ({
 }));
 vi.mock('../templates/template-service', () => ({
   copyCharacter: vi.fn(),
-  copyEntityPictureIfExists: vi.fn(),
   copyRelatedTemplateFiles: vi.fn(),
 }));
 vi.mock('@shared/db/functions/token-points', () => ({
@@ -793,7 +788,6 @@ describe('character-service', () => {
       );
 
       vi.mocked(copyCharacter).mockResolvedValue(insertedCharacter as never);
-      vi.mocked(copyEntityPictureIfExists).mockResolvedValue(undefined as never);
 
       const result = await createNewCharacter({
         federalStateId,
@@ -808,11 +802,6 @@ describe('character-service', () => {
         expect.objectContaining({ id: expect.any(String) }),
         duplicateCharacterName,
       );
-      expect(copyEntityPictureIfExists).toHaveBeenCalledWith({
-        sourcePictureId: null,
-        newEntityId: insertedCharacter.id,
-        buildPictureKey: expect.any(Function),
-      });
       expect(copyRelatedTemplateFiles).toHaveBeenCalledWith(
         'character',
         templateId,
@@ -821,33 +810,23 @@ describe('character-service', () => {
       expect(result).toBe(insertedCharacter);
     });
 
-    it('should update character picture when template picture is copied', async () => {
+    it('should return the character from copyCharacter as-is, without copying its picture again', async () => {
       const user = mockUser('teacher');
       const insertedCharacter = {
         id: generateUUID(),
-        pictureId: 'characters/template-id/original.png',
-      } as CharacterSelectModel;
-      const copiedPictureKey = `characters/${insertedCharacter.id}/original.png`;
-      const updatedCharacter = {
-        ...insertedCharacter,
-        pictureId: copiedPictureKey,
+        pictureId: 'characters/already-scoped-id/avatar_abc123',
       } as CharacterSelectModel;
 
       vi.mocked(dbGetCharacterById).mockResolvedValue(
         templateCharacter({ userId: user.id, accessLevel: 'private' }) as never,
       );
-
       vi.mocked(copyCharacter).mockResolvedValue(insertedCharacter as never);
-      vi.mocked(copyEntityPictureIfExists).mockResolvedValue(copiedPictureKey as never);
-      mockDbReturning.mockResolvedValue([updatedCharacter]);
 
-      const result = await createNewCharacter({
-        federalStateId,
-        templateId,
-        user,
-      });
+      const result = await createNewCharacter({ federalStateId, templateId, user });
 
-      expect(result).toEqual({ ...updatedCharacter, ownerSchoolIds: expect.any(Array) });
+      // copyCharacter already duplicates the picture; createNewCharacter must not attempt to
+      // copy it again (which would be a no-op S3 self-copy at best, an error at worst).
+      expect(result).toBe(insertedCharacter);
     });
 
     it('should throw ForbiddenError when template is suspended', async () => {

--- a/packages/shared/src/characters/character-service.ts
+++ b/packages/shared/src/characters/character-service.ts
@@ -52,11 +52,7 @@ import {
   MAX_SHARE_USAGE_TIME_LIMIT_IN_MINUTES,
   SHARE_EXTENSION_WINDOW_MS,
 } from '@shared/sharing/const';
-import {
-  copyCharacter,
-  copyEntityPictureIfExists,
-  copyRelatedTemplateFiles,
-} from '@shared/templates/template-service';
+import { copyCharacter, copyRelatedTemplateFiles } from '@shared/templates/template-service';
 import { OverviewFilter } from '@shared/overview-filter';
 import { removeNullishValues } from '@shared/utils/remove-nullish-values';
 import {
@@ -112,34 +108,12 @@ export const createNewCharacter = async ({
     });
     verifySuspensionState({ item: sourceCharacter });
 
-    let insertedCharacter = await copyCharacter(
+    const insertedCharacter = await copyCharacter(
       templateId,
       'private',
       user,
       duplicateCharacterName,
     );
-
-    const copyOfTemplatePicture = await copyEntityPictureIfExists({
-      sourcePictureId: insertedCharacter.pictureId,
-      newEntityId: insertedCharacter.id,
-      buildPictureKey: buildCharacterPictureKey,
-    });
-
-    if (copyOfTemplatePicture) {
-      // Update the character with the new picture
-      const [updatedCharacter] = await db
-        .update(characterTable)
-        .set({ pictureId: copyOfTemplatePicture })
-        .where(eq(characterTable.id, insertedCharacter.id))
-        .returning();
-
-      if (updatedCharacter) {
-        insertedCharacter = {
-          ...updatedCharacter,
-          ownerSchoolIds: user.schoolIds,
-        } as typeof insertedCharacter;
-      }
-    }
 
     await copyRelatedTemplateFiles('character', templateId, insertedCharacter.id);
     return insertedCharacter;

--- a/packages/shared/src/templates/fix-invalid-picture-ids.test.ts
+++ b/packages/shared/src/templates/fix-invalid-picture-ids.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, MockedFunction, vi } from 'vitest';
+import { fixInvalidPictureIds } from './fix-invalid-picture-ids';
+import { copyFileInS3 } from '@shared/s3';
+import { logError, logInfo } from '@shared/logging';
+
+const { mockDbWhere, mockDbSelect, mockUpdateSet, mockDbUpdate, mockClientQuery } = vi.hoisted(
+  () => {
+    const mockDbWhere = vi.fn();
+    const mockDbFrom = vi.fn(() => ({ where: mockDbWhere }));
+    const mockDbSelect = vi.fn(() => ({ from: mockDbFrom }));
+    const mockUpdateWhere = vi.fn();
+    const mockUpdateSet = vi.fn(() => ({ where: mockUpdateWhere }));
+    const mockDbUpdate = vi.fn(() => ({ set: mockUpdateSet }));
+    const mockClientQuery = vi.fn().mockResolvedValue(undefined);
+    return { mockDbWhere, mockDbSelect, mockUpdateSet, mockDbUpdate, mockClientQuery };
+  },
+);
+
+vi.mock('@shared/db', () => ({
+  db: {
+    select: mockDbSelect,
+    update: mockDbUpdate,
+    $client: { query: mockClientQuery },
+  },
+}));
+
+vi.mock('@shared/s3', () => ({ copyFileInS3: vi.fn() }));
+vi.mock('@shared/logging', () => ({ logInfo: vi.fn(), logError: vi.fn() }));
+
+describe('fixInvalidPictureIds', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClientQuery.mockResolvedValue(undefined);
+    // First select call = assistants, second = characters, in this order.
+    mockDbWhere.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+  });
+
+  it('takes and releases an advisory lock around the migration', async () => {
+    await fixInvalidPictureIds();
+
+    expect(mockClientQuery).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('pg_advisory_lock'),
+      [1000, 100003],
+    );
+    expect(mockClientQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('pg_advisory_unlock'),
+      [1000, 100003],
+    );
+  });
+
+  it('does nothing when there are no invalid picture ids', async () => {
+    await fixInvalidPictureIds();
+
+    expect(copyFileInS3).not.toHaveBeenCalled();
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+  });
+
+  it('skips rows with a nullish picture id', async () => {
+    mockDbWhere.mockReset();
+    mockDbWhere
+      .mockResolvedValueOnce([{ id: 'assistant-1', pictureId: null }])
+      .mockResolvedValueOnce([]);
+
+    await fixInvalidPictureIds();
+
+    expect(copyFileInS3).not.toHaveBeenCalled();
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+  });
+
+  it('copies the picture and updates the row when the source exists in S3', async () => {
+    mockDbWhere.mockReset();
+    mockDbWhere
+      .mockResolvedValueOnce([
+        { id: 'assistant-1', pictureId: 'custom-gpts/other-id/avatar_abc123' },
+      ])
+      .mockResolvedValueOnce([]);
+    (copyFileInS3 as MockedFunction<typeof copyFileInS3>).mockResolvedValue(undefined);
+
+    await fixInvalidPictureIds();
+
+    expect(copyFileInS3).toHaveBeenCalledWith({
+      copySource: 'custom-gpts/other-id/avatar_abc123',
+      newKey: 'custom-gpts/assistant-1/avatar_abc123',
+    });
+    expect(mockDbUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdateSet).toHaveBeenCalledWith({
+      pictureId: 'custom-gpts/assistant-1/avatar_abc123',
+    });
+  });
+
+  it('logs an info note and skips the row when the picture does not exist in S3', async () => {
+    mockDbWhere.mockReset();
+    mockDbWhere
+      .mockResolvedValueOnce([
+        { id: 'assistant-1', pictureId: 'custom-gpts/missing-id/avatar_missing' },
+      ])
+      .mockResolvedValueOnce([]);
+    (copyFileInS3 as MockedFunction<typeof copyFileInS3>).mockRejectedValue(new Error('NoSuchKey'));
+
+    await fixInvalidPictureIds();
+
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+    expect(logInfo).toHaveBeenCalledWith(expect.stringContaining('assistant-1'));
+  });
+
+  it('continues processing other rows when one row fails unexpectedly', async () => {
+    mockDbWhere.mockReset();
+    mockDbWhere
+      .mockResolvedValueOnce([
+        { id: 'assistant-1', pictureId: 'custom-gpts/other-id/avatar_abc123' },
+        { id: 'assistant-2', pictureId: 'custom-gpts/other-id-2/avatar_def456' },
+      ])
+      .mockResolvedValueOnce([]);
+    mockDbUpdate.mockImplementationOnce(() => {
+      throw new Error('DB unavailable');
+    });
+    (copyFileInS3 as MockedFunction<typeof copyFileInS3>).mockResolvedValue(undefined);
+
+    await fixInvalidPictureIds();
+
+    expect(copyFileInS3).toHaveBeenCalledTimes(2);
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('assistant-1'),
+      expect.any(Error),
+    );
+    expect(mockDbUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it('fixes characters using the character picture key convention', async () => {
+    mockDbWhere.mockReset();
+    mockDbWhere
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { id: 'character-1', pictureId: 'characters/other-id/avatar_abc123' },
+      ]);
+    (copyFileInS3 as MockedFunction<typeof copyFileInS3>).mockResolvedValue(undefined);
+
+    await fixInvalidPictureIds();
+
+    expect(copyFileInS3).toHaveBeenCalledWith({
+      copySource: 'characters/other-id/avatar_abc123',
+      newKey: 'characters/character-1/avatar_abc123',
+    });
+  });
+});

--- a/packages/shared/src/templates/fix-invalid-picture-ids.test.ts
+++ b/packages/shared/src/templates/fix-invalid-picture-ids.test.ts
@@ -3,24 +3,46 @@ import { fixInvalidPictureIds } from './fix-invalid-picture-ids';
 import { copyFileInS3 } from '@shared/s3';
 import { logError, logInfo } from '@shared/logging';
 
-const { mockDbWhere, mockDbSelect, mockUpdateSet, mockDbUpdate, mockClientQuery } = vi.hoisted(
-  () => {
-    const mockDbWhere = vi.fn();
-    const mockDbFrom = vi.fn(() => ({ where: mockDbWhere }));
-    const mockDbSelect = vi.fn(() => ({ from: mockDbFrom }));
-    const mockUpdateWhere = vi.fn();
-    const mockUpdateSet = vi.fn(() => ({ where: mockUpdateWhere }));
-    const mockDbUpdate = vi.fn(() => ({ set: mockUpdateSet }));
-    const mockClientQuery = vi.fn().mockResolvedValue(undefined);
-    return { mockDbWhere, mockDbSelect, mockUpdateSet, mockDbUpdate, mockClientQuery };
-  },
-);
+const {
+  mockDbWhere,
+  mockDbSelect,
+  mockUpdateSet,
+  mockUpdateReturning,
+  mockDbUpdate,
+  mockClientQuery,
+  mockClientRelease,
+  mockClientConnect,
+} = vi.hoisted(() => {
+  const mockDbWhere = vi.fn();
+  const mockDbFrom = vi.fn(() => ({ where: mockDbWhere }));
+  const mockDbSelect = vi.fn(() => ({ from: mockDbFrom }));
+  const mockUpdateReturning = vi.fn();
+  const mockUpdateWhere = vi.fn(() => ({ returning: mockUpdateReturning }));
+  const mockUpdateSet = vi.fn(() => ({ where: mockUpdateWhere }));
+  const mockDbUpdate = vi.fn(() => ({ set: mockUpdateSet }));
+  const mockClientQuery = vi.fn().mockResolvedValue(undefined);
+  const mockClientRelease = vi.fn();
+  const mockClientConnect = vi.fn().mockResolvedValue({
+    query: mockClientQuery,
+    release: mockClientRelease,
+  });
+  return {
+    mockDbWhere,
+    mockDbSelect,
+    mockUpdateSet,
+    mockUpdateReturning,
+    mockDbUpdate,
+    mockClientQuery,
+    mockClientRelease,
+    mockClientConnect,
+  };
+});
 
 vi.mock('@shared/db', () => ({
   db: {
     select: mockDbSelect,
     update: mockDbUpdate,
-    $client: { query: mockClientQuery },
+    $client: { connect: mockClientConnect },
   },
 }));
 
@@ -31,13 +53,16 @@ describe('fixInvalidPictureIds', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockClientQuery.mockResolvedValue(undefined);
+    mockClientConnect.mockResolvedValue({ query: mockClientQuery, release: mockClientRelease });
+    mockUpdateReturning.mockResolvedValue([{ id: 'updated-id' }]);
     // First select call = assistants, second = characters, in this order.
     mockDbWhere.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
   });
 
-  it('takes and releases an advisory lock around the migration', async () => {
+  it('takes and releases an advisory lock on a dedicated client', async () => {
     await fixInvalidPictureIds();
 
+    expect(mockClientConnect).toHaveBeenCalledTimes(1);
     expect(mockClientQuery).toHaveBeenNthCalledWith(
       1,
       expect.stringContaining('pg_advisory_lock'),
@@ -48,6 +73,16 @@ describe('fixInvalidPictureIds', () => {
       expect.stringContaining('pg_advisory_unlock'),
       [1000, 100003],
     );
+    expect(mockClientRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the client even if the migration throws', async () => {
+    mockDbWhere.mockReset();
+    mockDbWhere.mockRejectedValueOnce(new Error('select failed'));
+
+    await expect(fixInvalidPictureIds()).rejects.toThrow('select failed');
+
+    expect(mockClientRelease).toHaveBeenCalledTimes(1);
   });
 
   it('does nothing when there are no invalid picture ids', async () => {
@@ -88,6 +123,21 @@ describe('fixInvalidPictureIds', () => {
     expect(mockUpdateSet).toHaveBeenCalledWith({
       pictureId: 'custom-gpts/assistant-1/avatar_abc123',
     });
+  });
+
+  it('skips the update when the picture id changed concurrently', async () => {
+    mockDbWhere.mockReset();
+    mockDbWhere
+      .mockResolvedValueOnce([
+        { id: 'assistant-1', pictureId: 'custom-gpts/other-id/avatar_abc123' },
+      ])
+      .mockResolvedValueOnce([]);
+    (copyFileInS3 as MockedFunction<typeof copyFileInS3>).mockResolvedValue(undefined);
+    mockUpdateReturning.mockResolvedValueOnce([]);
+
+    await fixInvalidPictureIds();
+
+    expect(logInfo).toHaveBeenCalledWith(expect.stringContaining('changed concurrently'));
   });
 
   it('logs an info note and skips the row when the picture does not exist in S3', async () => {

--- a/packages/shared/src/templates/fix-invalid-picture-ids.ts
+++ b/packages/shared/src/templates/fix-invalid-picture-ids.ts
@@ -1,0 +1,139 @@
+/**
+ * @description One-off data-repair migration for TD-1498.
+ */
+import { and, eq, isNotNull, ne, sql } from 'drizzle-orm';
+import { db } from '@shared/db';
+import { assistantTable, characterTable } from '@shared/db/schema';
+import { copyFileInS3 } from '@shared/s3';
+import { buildAssistantPictureKey, buildCharacterPictureKey } from '@shared/utils/picture-key';
+import { logError, logInfo } from '@shared/logging';
+import path from 'node:path';
+
+const LOCK_KEY1 = 1000;
+const LOCK_KEY2 = 100003;
+
+/** Ensures the migration only runs on a single pod at a time; other pods wait their turn. */
+async function withAdvisoryLock(callback: () => Promise<void>) {
+  const pool = db.$client;
+  await pool.query(`SELECT pg_advisory_lock($1, $2)`, [LOCK_KEY1, LOCK_KEY2]);
+  try {
+    await callback();
+  } finally {
+    await pool.query(`SELECT pg_advisory_unlock($1, $2)`, [LOCK_KEY1, LOCK_KEY2]);
+  }
+}
+
+function dbGetAssistantsWithInvalidPictureIds() {
+  return db
+    .select({ id: assistantTable.id, pictureId: assistantTable.pictureId })
+    .from(assistantTable)
+    .where(
+      and(
+        isNotNull(assistantTable.pictureId),
+        ne(assistantTable.pictureId, ''),
+        sql`${assistantTable.pictureId} NOT LIKE '%' || ${assistantTable.id} || '%'`,
+      ),
+    );
+}
+
+function dbGetCharactersWithInvalidPictureIds() {
+  return db
+    .select({ id: characterTable.id, pictureId: characterTable.pictureId })
+    .from(characterTable)
+    .where(
+      and(
+        isNotNull(characterTable.pictureId),
+        ne(characterTable.pictureId, ''),
+        sql`${characterTable.pictureId} NOT LIKE '%' || ${characterTable.id} || '%'`,
+      ),
+    );
+}
+
+async function fixAssistantPictureIds() {
+  const assistants = await dbGetAssistantsWithInvalidPictureIds();
+  if (assistants.length === 0) {
+    return;
+  }
+
+  logInfo(`Found ${assistants.length} assistants with invalid picture ids.`);
+
+  for (const assistant of assistants) {
+    try {
+      const oldPictureId = assistant.pictureId;
+      if (!oldPictureId) {
+        continue;
+      }
+
+      const newPictureId = buildAssistantPictureKey(assistant.id, path.basename(oldPictureId));
+
+      try {
+        await copyFileInS3({ copySource: oldPictureId, newKey: newPictureId });
+      } catch {
+        // copyFileInS3 already logs the underlying error; just note which entity needs manual fixing
+        logInfo(
+          `Could not copy picture ${oldPictureId} for assistant ${assistant.id}, it likely does not exist in S3. Needs manual fixing.`,
+        );
+        continue;
+      }
+
+      await db
+        .update(assistantTable)
+        .set({ pictureId: newPictureId })
+        .where(eq(assistantTable.id, assistant.id));
+      logInfo(`Fixed picture id for assistant ${assistant.id}`);
+    } catch (error) {
+      logError(`Failed to fix invalid picture id for assistant ${assistant.id}`, error);
+    }
+  }
+}
+
+async function fixCharacterPictureIds() {
+  const characters = await dbGetCharactersWithInvalidPictureIds();
+  if (characters.length === 0) {
+    return;
+  }
+
+  logInfo(`Found ${characters.length} characters with invalid picture ids.`);
+
+  for (const character of characters) {
+    try {
+      const oldPictureId = character.pictureId;
+      if (!oldPictureId) {
+        continue;
+      }
+
+      const newPictureId = buildCharacterPictureKey(character.id, path.basename(oldPictureId));
+
+      try {
+        await copyFileInS3({ copySource: oldPictureId, newKey: newPictureId });
+      } catch {
+        // copyFileInS3 already logs the underlying error; just note which entity needs manual fixing
+        logInfo(
+          `Could not copy picture ${oldPictureId} for character ${character.id}, it likely does not exist in S3. Needs manual fixing.`,
+        );
+        continue;
+      }
+
+      await db
+        .update(characterTable)
+        .set({ pictureId: newPictureId })
+        .where(eq(characterTable.id, character.id));
+      logInfo(`Fixed picture id for character ${character.id}`);
+    } catch (error) {
+      logError(`Failed to fix invalid picture id for character ${character.id}`, error);
+    }
+  }
+}
+
+/**
+ * Fixes assistants and characters whose picture ids reference another entity's S3 object,
+ * by duplicating the referenced picture into a key scoped to their own id.
+ */
+export async function fixInvalidPictureIds() {
+  await withAdvisoryLock(async () => {
+    logInfo('Starting migration to fix invalid picture ids...');
+    await fixAssistantPictureIds();
+    await fixCharacterPictureIds();
+    logInfo('Completed fix for invalid picture ids.');
+  });
+}

--- a/packages/shared/src/templates/fix-invalid-picture-ids.ts
+++ b/packages/shared/src/templates/fix-invalid-picture-ids.ts
@@ -14,12 +14,16 @@ const LOCK_KEY2 = 100003;
 
 /** Ensures the migration only runs on a single pod at a time; other pods wait their turn. */
 async function withAdvisoryLock(callback: () => Promise<void>) {
-  const pool = db.$client;
-  await pool.query(`SELECT pg_advisory_lock($1, $2)`, [LOCK_KEY1, LOCK_KEY2]);
+  const client = await db.$client.connect();
   try {
-    await callback();
+    await client.query('SELECT pg_advisory_lock($1, $2)', [LOCK_KEY1, LOCK_KEY2]);
+    try {
+      await callback();
+    } finally {
+      await client.query('SELECT pg_advisory_unlock($1, $2)', [LOCK_KEY1, LOCK_KEY2]);
+    }
   } finally {
-    await pool.query(`SELECT pg_advisory_unlock($1, $2)`, [LOCK_KEY1, LOCK_KEY2]);
+    client.release();
   }
 }
 
@@ -76,10 +80,16 @@ async function fixAssistantPictureIds() {
         continue;
       }
 
-      await db
+      const updated = await db
         .update(assistantTable)
         .set({ pictureId: newPictureId })
-        .where(eq(assistantTable.id, assistant.id));
+        .where(and(eq(assistantTable.id, assistant.id), eq(assistantTable.pictureId, oldPictureId)))
+        .returning({ id: assistantTable.id });
+
+      if (updated.length === 0) {
+        logInfo(`Skipped assistant ${assistant.id}: picture id changed concurrently.`);
+        continue;
+      }
       logInfo(`Fixed picture id for assistant ${assistant.id}`);
     } catch (error) {
       logError(`Failed to fix invalid picture id for assistant ${assistant.id}`, error);
@@ -114,10 +124,16 @@ async function fixCharacterPictureIds() {
         continue;
       }
 
-      await db
+      const updated = await db
         .update(characterTable)
         .set({ pictureId: newPictureId })
-        .where(eq(characterTable.id, character.id));
+        .where(and(eq(characterTable.id, character.id), eq(characterTable.pictureId, oldPictureId)))
+        .returning({ id: characterTable.id });
+
+      if (updated.length === 0) {
+        logInfo(`Skipped character ${character.id}: picture id changed concurrently.`);
+        continue;
+      }
       logInfo(`Fixed picture id for character ${character.id}`);
     } catch (error) {
       logError(`Failed to fix invalid picture id for character ${character.id}`, error);

--- a/packages/shared/src/templates/template-service.test.ts
+++ b/packages/shared/src/templates/template-service.test.ts
@@ -13,6 +13,7 @@ import {
   dbGetRelatedAssistantFiles,
   dbGetRelatedCharacterFiles,
 } from '@shared/db/functions/files';
+import { dbGetLearningScenarioById } from '@shared/db/functions/learning-scenario';
 import {
   duplicateFileWithEmbeddings,
   linkFileToAssistant,
@@ -21,6 +22,7 @@ import {
 } from '@shared/files/fileService';
 import { logError } from '@shared/logging';
 import { copyFileInS3 } from '@shared/s3';
+import { generateUUID } from '@shared/utils/uuid';
 
 vi.mock('@shared/db/functions/assistants', () => ({
   dbGetAssistantById: vi.fn(),
@@ -38,6 +40,10 @@ vi.mock('@shared/db/functions/files', () => ({
   dbGetFilesForLearningScenario: vi.fn(),
 }));
 
+vi.mock('@shared/db/functions/learning-scenario', () => ({
+  dbGetLearningScenarioById: vi.fn(),
+}));
+
 vi.mock('@shared/files/fileService', () => ({
   duplicateFileWithEmbeddings: vi.fn(),
   linkFileToAssistant: vi.fn(),
@@ -53,6 +59,17 @@ vi.mock('@shared/logging', () => ({
 vi.mock('@shared/s3', () => ({
   copyFileInS3: vi.fn(),
 }));
+
+const { mockDbReturning, mockDbValues, mockDbInsert } = vi.hoisted(() => {
+  const mockDbReturning = vi.fn();
+  const mockDbValues = vi.fn<
+    (values: Record<string, unknown>) => { returning: typeof mockDbReturning }
+  >(() => ({ returning: mockDbReturning }));
+  const mockDbInsert = vi.fn(() => ({ values: mockDbValues }));
+  return { mockDbReturning, mockDbValues, mockDbInsert };
+});
+
+vi.mock('@shared/db', () => ({ db: { insert: mockDbInsert } }));
 
 describe('template-service', () => {
   beforeEach(() => {
@@ -94,7 +111,7 @@ describe('template-service', () => {
     });
 
     it('should bubble up s3 copy errors', async () => {
-      (copyFileInS3 as MockedFunction<typeof copyFileInS3>).mockRejectedValue(
+      (copyFileInS3 as MockedFunction<typeof copyFileInS3>).mockRejectedValueOnce(
         new Error('S3 copy failed') as never,
       );
 
@@ -145,6 +162,30 @@ describe('template-service', () => {
         }),
       });
       expect(result).toBe(upsertedAssistant);
+    });
+
+    it('should duplicate the picture in S3 under a key scoped to the new assistant id', async () => {
+      const sourceAssistant = {
+        id: 'assistant-origin',
+        name: 'Original name',
+        pictureId: 'custom-gpts/assistant-origin/avatar_abc123',
+      };
+      (dbGetAssistantById as MockedFunction<typeof dbGetAssistantById>).mockResolvedValue(
+        sourceAssistant as never,
+      );
+      (dbUpsertAssistant as MockedFunction<typeof dbUpsertAssistant>).mockResolvedValue({
+        id: 'assistant-copy',
+      } as never);
+
+      await copyAssistant('assistant-origin', 'global', { id: 'user-1' });
+
+      const call = (dbUpsertAssistant as MockedFunction<typeof dbUpsertAssistant>).mock
+        .calls[0]?.[0];
+      expect(copyFileInS3).toHaveBeenCalledWith({
+        copySource: 'custom-gpts/assistant-origin/avatar_abc123',
+        newKey: call?.assistant.pictureId,
+      });
+      expect(call?.assistant.pictureId).not.toContain('assistant-origin');
     });
 
     it('should fallback to source name when duplicateAssistantName is not provided', async () => {
@@ -233,6 +274,30 @@ describe('template-service', () => {
         }),
       );
       expect(result).toBe(createdCharacter);
+    });
+
+    it('should duplicate the picture in S3 under a key scoped to the new character id', async () => {
+      const sourceCharacter = {
+        id: 'character-origin',
+        name: 'Original character',
+        pictureId: 'characters/character-origin/avatar_abc123',
+      };
+      (dbGetCharacterById as MockedFunction<typeof dbGetCharacterById>).mockResolvedValue(
+        sourceCharacter as never,
+      );
+      (dbCreateCharacter as MockedFunction<typeof dbCreateCharacter>).mockResolvedValue([
+        { id: 'character-copy' },
+      ] as never);
+
+      await copyCharacter('character-origin', 'global', { id: 'user-1' });
+
+      const call = (dbCreateCharacter as MockedFunction<typeof dbCreateCharacter>).mock
+        .calls[0]?.[0];
+      expect(copyFileInS3).toHaveBeenCalledWith({
+        copySource: 'characters/character-origin/avatar_abc123',
+        newKey: call?.pictureId,
+      });
+      expect(call?.pictureId).not.toContain('character-origin');
     });
 
     it('should fallback to source name when duplicateCharacterName is not provided', async () => {
@@ -383,6 +448,33 @@ describe('template-service', () => {
   describe('createTemplateFromUrl', () => {
     it('should throw on invalid url format', async () => {
       await expect(createTemplateFromUrl('/invalid/url')).rejects.toThrow('Invalid url format.');
+    });
+
+    it('should duplicate the learning scenario picture in S3 under a key scoped to the new template id', async () => {
+      const originalId = generateUUID();
+      (
+        dbGetLearningScenarioById as MockedFunction<typeof dbGetLearningScenarioById>
+      ).mockResolvedValue({
+        id: originalId,
+        name: 'Original name',
+        modelId: generateUUID(),
+        userId: generateUUID(),
+        accessLevel: 'private',
+        pictureId: `shared-chats/${originalId}/avatar_abc123`,
+      } as never);
+      mockDbReturning.mockResolvedValue([{ id: generateUUID() }]);
+      (
+        dbGetFilesForLearningScenario as MockedFunction<typeof dbGetFilesForLearningScenario>
+      ).mockResolvedValue([]);
+
+      await createTemplateFromUrl(`/learning-scenarios/editor/${originalId}`);
+
+      const call = mockDbValues.mock.calls[0]?.[0];
+      expect(copyFileInS3).toHaveBeenCalledWith({
+        copySource: `shared-chats/${originalId}/avatar_abc123`,
+        newKey: call?.pictureId,
+      });
+      expect(call?.pictureId).not.toContain(originalId);
     });
   });
 });

--- a/packages/shared/src/templates/template-service.ts
+++ b/packages/shared/src/templates/template-service.ts
@@ -36,7 +36,11 @@ import {
   linkFileToCharacter,
   linkFileToLearningScenario,
 } from '@shared/files/fileService';
-import { buildLearningScenarioPictureKey } from '@shared/utils/picture-key';
+import {
+  buildAssistantPictureKey,
+  buildCharacterPictureKey,
+  buildLearningScenarioPictureKey,
+} from '@shared/utils/picture-key';
 import { dbGetLearningScenarioById } from '@shared/db/functions/learning-scenario';
 import { NotFoundError } from '@shared/error';
 import { copyFileInS3 } from '@shared/s3';
@@ -536,15 +540,22 @@ export async function copyAssistant(
     throw new Error('Assistent nicht gefunden');
   }
 
+  const newAssistantId = generateUUID();
+
   const newAssistant = {
     ...sourceAssistant,
     name: (duplicateAssistantName ?? sourceAssistant.name).substring(0, MAX_ENTITY_NAME_LENGTH),
-    id: undefined,
+    id: newAssistantId,
     originalAssistantId: originalId,
     accessLevel,
     userId: user.id,
     isDeleted: false,
     hasLinkAccess: false, // Reset sharing settings for new template
+    pictureId: await copyEntityPictureIfExists({
+      sourcePictureId: sourceAssistant.pictureId,
+      newEntityId: newAssistantId,
+      buildPictureKey: buildAssistantPictureKey,
+    }),
   };
 
   const result = await dbUpsertAssistant({ assistant: newAssistant });
@@ -591,15 +602,22 @@ export async function copyCharacter(
     throw new Error('Dialogpartner nicht gefunden');
   }
 
+  const newCharacterId = generateUUID();
+
   const newCharacter = {
     ...sourceCharacter,
     name: (duplicateCharacterName ?? sourceCharacter.name).substring(0, MAX_ENTITY_NAME_LENGTH),
-    id: undefined,
+    id: newCharacterId,
     originalCharacterId: originalId,
     accessLevel,
     userId: user.id,
     isDeleted: false,
     hasLinkAccess: false, // Reset sharing settings for new template
+    pictureId: await copyEntityPictureIfExists({
+      sourcePictureId: sourceCharacter.pictureId,
+      newEntityId: newCharacterId,
+      buildPictureKey: buildCharacterPictureKey,
+    }),
   };
 
   const result = await dbCreateCharacter(newCharacter);
@@ -628,43 +646,52 @@ async function createCharacterTemplate(originalId: string) {
  * @param originalId - The id of the source learning scenario to create a template from.
  */
 async function createLearningScenarioTemplate(originalId: string) {
-  return copyLearningScenario(originalId, { id: DUMMY_USER_ID });
+  return copyLearningScenario(originalId, 'global', { id: DUMMY_USER_ID });
 }
 
 /**
- * Creates a new global learning scenario template based on an existing learning scenario.
+ * Copies a learning scenario and creates a new one based on an existing learning scenario.
+ * The new learning scenario inherits all properties from the source but can have customized
+ * access level, user, and school assignments.
  *
- * @param learningScenarioId - The id of the source learning scenario to copy
+ * @param originalId - The id of the source learning scenario to copy
+ * @param accessLevel - The access level for the new learning scenario
  * @param user - The user that is the owner of the new learning scenario
- * @returns
+ * @param duplicateLearningScenarioName - Optional custom name for the new learning scenario. If not provided, uses the source learning scenario's name.
+ * @returns Promise resolving to the newly created learning scenario object
+ * @throws Error if source learning scenario is not found or creation fails
  */
 async function copyLearningScenario(
-  learningScenarioId: string,
+  originalId: string,
+  accessLevel: AccessLevel,
   user: Pick<UserModel, 'id'>,
   duplicateLearningScenarioName?: string,
 ) {
-  const learningScenario = await dbGetLearningScenarioById({ learningScenarioId });
+  const learningScenario = await dbGetLearningScenarioById({ learningScenarioId: originalId });
   if (!learningScenario) {
     throw new NotFoundError('Original learning scenario not found');
   }
 
-  const copy = learningScenarioInsertSchema.parse(learningScenario);
-  copy.id = generateUUID();
-  copy.accessLevel = 'global';
-  copy.isDeleted = false;
-  copy.userId = user.id;
-  copy.originalLearningScenarioId = learningScenarioId;
-  copy.hasLinkAccess = false; // Reset sharing settings for new template
-  copy.name = (duplicateLearningScenarioName ?? learningScenario.name).substring(
-    0,
-    MAX_ENTITY_NAME_LENGTH,
-  );
+  const newLearningScenarioId = generateUUID();
 
-  copy.pictureId = await copyEntityPictureIfExists({
-    sourcePictureId: learningScenario.pictureId,
-    newEntityId: copy.id,
-    buildPictureKey: buildLearningScenarioPictureKey,
-  });
+  const copy = {
+    ...learningScenarioInsertSchema.parse(learningScenario),
+    name: (duplicateLearningScenarioName ?? learningScenario.name).substring(
+      0,
+      MAX_ENTITY_NAME_LENGTH,
+    ),
+    id: newLearningScenarioId,
+    originalLearningScenarioId: originalId,
+    accessLevel,
+    userId: user.id,
+    isDeleted: false,
+    hasLinkAccess: false, // Reset sharing settings for new template
+    pictureId: await copyEntityPictureIfExists({
+      sourcePictureId: learningScenario.pictureId,
+      newEntityId: newLearningScenarioId,
+      buildPictureKey: buildLearningScenarioPictureKey,
+    }),
+  };
   // attachments are copied in a separate step atm after the template is created
 
   const [newLearningScenario] = await db.insert(learningScenarioTable).values(copy).returning();


### PR DESCRIPTION
Creating a global template from an assistant/character kept referencing the source entity's S3 picture instead of duplicating it. Mirrors the existing correct learning-scenario behavior.

- Adds a one-off, lock-guarded migration (`fixInvalidPictureIds`) to repair already-affected rows; rows whose picture is missing in S3 are logged for manual follow-up.
- Removes the now-redundant (and S3-self-copy-erroring) picture copy that `createNewAssistant`/`createNewCharacter` previously did on top of `copyAssistant`/`copyCharacter`, since those now duplicate the picture themselves.
- Aligns `copyLearningScenario`'s signature with `copyAssistant`/`copyCharacter` (explicit `accessLevel`), kept unexported since it has no external callers.