### PR TITLE
TD-1388: Fix width/height query param parsing in scaled-image route

### DIFF
--- a/apps/chat-bot/src/app/api/files/[fileId]/scaled-image/route.test.ts
+++ b/apps/chat-bot/src/app/api/files/[fileId]/scaled-image/route.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/auth/utils', () => ({
+  getUser: vi.fn(),
+}));
+vi.mock('@shared/db/functions/files', () => ({
+  dbVerifyFileOwnership: vi.fn(),
+}));
+vi.mock('@/app/api/file-operations/scaled-image-service', () => ({
+  createScaledImage: vi.fn(),
+}));
+
+import { getUser } from '@/auth/utils';
+import { dbVerifyFileOwnership } from '@shared/db/functions/files';
+import { createScaledImage } from '@/app/api/file-operations/scaled-image-service';
+import { GET } from './route';
+
+const params = Promise.resolve({ fileId: 'file-1' });
+
+function buildRequest(searchParams: string) {
+  return new NextRequest(`https://example.com/api/files/file-1/scaled-image${searchParams}`);
+}
+
+describe('GET /api/files/[fileId]/scaled-image', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getUser).mockResolvedValue({ id: 'user-1' } as never);
+    vi.mocked(dbVerifyFileOwnership).mockResolvedValue(true);
+    vi.mocked(createScaledImage).mockResolvedValue({
+      buffer: Buffer.from('image-data'),
+      contentType: 'image/png',
+    } as never);
+  });
+
+  it('parses width/height query params and returns the scaled image', async () => {
+    const response = await GET(buildRequest('?width=100&height=200'), { params });
+
+    expect(response.status).toBe(200);
+    expect(createScaledImage).toHaveBeenCalledWith({
+      fileId: 'file-1',
+      width: 100,
+      height: 200,
+    });
+  });
+
+  it('returns 400 when width/height are missing', async () => {
+    const response = await GET(buildRequest(''), { params });
+
+    expect(response.status).toBe(400);
+    expect(createScaledImage).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when width/height are invalid', async () => {
+    const response = await GET(buildRequest('?width=abc&height=200'), { params });
+
+    expect(response.status).toBe(400);
+    expect(createScaledImage).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the user does not own the file', async () => {
+    vi.mocked(dbVerifyFileOwnership).mockResolvedValue(false);
+
+    const response = await GET(buildRequest('?width=100&height=200'), { params });
+
+    expect(response.status).toBe(403);
+    expect(createScaledImage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/chat-bot/src/app/api/files/[fileId]/scaled-image/route.ts
+++ b/apps/chat-bot/src/app/api/files/[fileId]/scaled-image/route.ts
@@ -23,7 +23,9 @@ export async function GET(
       return NextResponse.json({ error: 'Not authorized to access this file' }, { status: 403 });
     }
 
-    const dimensions = imageDimensionsSchema.safeParse(request.nextUrl.searchParams);
+    const dimensions = imageDimensionsSchema.safeParse(
+      Object.fromEntries(request.nextUrl.searchParams),
+    );
     if (!dimensions.success) {
       return NextResponse.json({ error: 'Invalid width/height' }, { status: 400 });
     }


### PR DESCRIPTION
- `imageDimensionsSchema.safeParse` was called directly on `request.nextUrl.searchParams` (a `URLSearchParams` instance), which Zod's object schema can't read properties from — validation always failed.
- Fix: convert to a plain object with `Object.fromEntries(...)` before parsing.
- Added `route.test.ts` covering valid params, missing params, invalid params, and non-owner access.