### PR TITLE
TD-975: Add uploaded file context to messages

### DIFF
--- a/apps/chat-bot/src/app/api/character/character-chat-service.test.ts
+++ b/apps/chat-bot/src/app/api/character/character-chat-service.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   enrichMessagesWithImageDataMock: vi.fn(),
   getMostRecentUserMessageMock: vi.fn(),
   limitChatHistoryMock: vi.fn(),
+  annotateMessageAttachmentNamesMock: vi.fn(),
   logErrorMock: vi.fn(),
   buildToolsMock: vi.fn(),
   createImageAttachmentsForConversationMock: vi.fn(),
@@ -92,6 +93,7 @@ vi.mock('../chat/utils', () => ({
   enrichMessagesWithImageData: mocks.enrichMessagesWithImageDataMock,
   getMostRecentUserMessage: mocks.getMostRecentUserMessageMock,
   limitChatHistory: mocks.limitChatHistoryMock,
+  annotateMessageAttachmentNames: mocks.annotateMessageAttachmentNamesMock,
 }));
 
 vi.mock('@shared/logging', () => ({
@@ -191,6 +193,9 @@ beforeEach(() => {
   mocks.buildToolsMock.mockResolvedValue({ toolRegistry: {} });
   mocks.constructCharacterSystemPromptMock.mockReturnValue('system-prompt');
   mocks.limitChatHistoryMock.mockImplementation(
+    (incomingMessages: ChatMessage[]) => incomingMessages,
+  );
+  mocks.annotateMessageAttachmentNamesMock.mockImplementation(
     (incomingMessages: ChatMessage[]) => incomingMessages,
   );
   mocks.getMostRecentUserMessageMock.mockImplementation((incomingMessages: ChatMessage[]) =>

--- a/apps/chat-bot/src/app/api/character/character-chat-service.ts
+++ b/apps/chat-bot/src/app/api/character/character-chat-service.ts
@@ -20,6 +20,7 @@ import {
   enrichMessagesWithImageData,
   getMostRecentUserMessage,
   limitChatHistory,
+  annotateMessageAttachmentNames,
 } from '../chat/utils';
 import { logError } from '@shared/logging';
 import { buildTools } from '../chat/build-tools';
@@ -184,7 +185,7 @@ export async function sendCharacterMessage({
 
   // Format messages with images if the model supports vision
   const messagesWithImages = enrichMessagesWithImageData(
-    prunedMessages,
+    annotateMessageAttachmentNames(prunedMessages, relatedFileEntities),
     extractedImages,
     modelSupportsImages,
     imageAttachmentType,

--- a/apps/chat-bot/src/app/api/character/character-chat-service.ts
+++ b/apps/chat-bot/src/app/api/character/character-chat-service.ts
@@ -169,7 +169,9 @@ export async function sendCharacterMessage({
   });
 
   // Prune messages
-  const prunedMessages = limitChatHistory(messages);
+  const prunedMessages = limitChatHistory(
+    annotateMessageAttachmentNames(messages, relatedFileEntities),
+  );
 
   // Check if the model supports images based on supportedImageFormats
   const modelSupportsImages =
@@ -185,7 +187,7 @@ export async function sendCharacterMessage({
 
   // Format messages with images if the model supports vision
   const messagesWithImages = enrichMessagesWithImageData(
-    annotateMessageAttachmentNames(prunedMessages, relatedFileEntities),
+    prunedMessages,
     extractedImages,
     modelSupportsImages,
     imageAttachmentType,

--- a/apps/chat-bot/src/app/api/chat/chat-service.test.ts
+++ b/apps/chat-bot/src/app/api/chat/chat-service.test.ts
@@ -60,6 +60,7 @@ const mocks = vi.hoisted(() => ({
   convertToAiCoreMessagesMock: vi.fn(),
   getChatTitleMock: vi.fn(),
   limitChatHistoryMock: vi.fn(),
+  annotateMessageAttachmentNamesMock: vi.fn(),
   extractUrlsMock: vi.fn(),
   createImageAttachmentsForConversationMock: vi.fn(),
   ingestWebContentMock: vi.fn(),
@@ -140,6 +141,7 @@ vi.mock('./utils', () => ({
   convertToAiCoreMessages: mocks.convertToAiCoreMessagesMock,
   getChatTitle: mocks.getChatTitleMock,
   limitChatHistory: mocks.limitChatHistoryMock,
+  annotateMessageAttachmentNames: mocks.annotateMessageAttachmentNamesMock,
 }));
 
 vi.mock('../utils/extract-urls', () => ({
@@ -267,7 +269,11 @@ beforeEach(() => {
   mocks.ingestWebContentMock.mockResolvedValue({ processedUrls: [], errorUrls: [] });
   mocks.dbGetAttachedFileByEntityIdMock.mockResolvedValue([]);
   mocks.limitChatHistoryMock.mockImplementation(
-    ({ messages }: { messages: ChatMessage[] }) => messages,
+    (incoming: ChatMessage[] | { messages: ChatMessage[] }) =>
+      Array.isArray(incoming) ? incoming : incoming.messages,
+  );
+  mocks.annotateMessageAttachmentNamesMock.mockImplementation(
+    (incomingMessages: ChatMessage[]) => incomingMessages,
   );
   mocks.enrichMessagesWithImageDataMock.mockImplementation((messages: ChatMessage[]) => messages);
   mocks.createImageAttachmentsForConversationMock.mockResolvedValue([]);
@@ -312,6 +318,38 @@ beforeEach(() => {
 });
 
 describe('sendChatMessage', () => {
+  it('passes attachment annotations to the model without persisting them', async () => {
+    const file = { id: 'upload-1', name: 'upload.pdf', conversationMessageId: 'message-3' };
+    mocks.dbGetAttachedFileByEntityIdMock.mockResolvedValue([file]);
+    mocks.annotateMessageAttachmentNamesMock.mockImplementation((incoming: ChatMessage[]) =>
+      incoming.map((message) =>
+        message.id === 'message-3'
+          ? { ...message, content: `${message.content}\n<attachment_metadata>` }
+          : message,
+      ),
+    );
+
+    const { sendChatMessage } = await import('./chat-service');
+    const result = await sendChatMessage({
+      conversationId: conversation.id,
+      messages,
+      modelId: mainModel.id,
+      user: createUser(),
+      fileIds: ['upload-1'],
+    });
+    await collectStream(result.stream);
+
+    expect(mocks.convertToAiCoreMessagesMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.arrayContaining([
+        expect.objectContaining({ content: expect.stringContaining('<attachment_metadata>') }),
+      ]),
+    );
+    expect(mocks.dbInsertChatContentMock).toHaveBeenCalledWith(
+      expect.objectContaining({ content: 'Current question' }),
+    );
+  });
+
   it('runs the agentic chat pipeline and persists the assistant message', async () => {
     const { sendChatMessage } = await import('./chat-service');
 

--- a/apps/chat-bot/src/app/api/chat/chat-service.test.ts
+++ b/apps/chat-bot/src/app/api/chat/chat-service.test.ts
@@ -324,7 +324,7 @@ describe('sendChatMessage', () => {
     mocks.annotateMessageAttachmentNamesMock.mockImplementation((incoming: ChatMessage[]) =>
       incoming.map((message) =>
         message.id === 'message-3'
-          ? { ...message, content: `${message.content}\n<attachment_metadata>` }
+          ? { ...message, content: `${message.content}\n<attachments>` }
           : message,
       ),
     );
@@ -342,7 +342,7 @@ describe('sendChatMessage', () => {
     expect(mocks.convertToAiCoreMessagesMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.arrayContaining([
-        expect.objectContaining({ content: expect.stringContaining('<attachment_metadata>') }),
+        expect.objectContaining({ content: expect.stringContaining('<attachments>') }),
       ]),
     );
     expect(mocks.dbInsertChatContentMock).toHaveBeenCalledWith(

--- a/apps/chat-bot/src/app/api/chat/chat-service.ts
+++ b/apps/chat-bot/src/app/api/chat/chat-service.ts
@@ -419,7 +419,9 @@ export async function sendChatMessage({
     : [...convertMessageModelToMessage(activeConversationMessages), userMessage];
 
   // Prune messages
-  const prunedMessages = limitChatHistory(fullMessages);
+  const prunedMessages = limitChatHistory(
+    annotateMessageAttachmentNames(fullMessages, relatedFileEntities),
+  );
 
   // Build system prompt
   const systemPrompt = constructChatSystemPrompt({
@@ -444,12 +446,8 @@ export async function sendChatMessage({
   );
 
   // Format messages with images if the model supports vision
-  const messagesWithAttachmentNames = annotateMessageAttachmentNames(
-    prunedMessages,
-    relatedFileEntities,
-  );
   const messagesWithImages = enrichMessagesWithImageData(
-    messagesWithAttachmentNames,
+    prunedMessages,
     extractedImages,
     modelSupportsImages,
     imageAttachmentType,

--- a/apps/chat-bot/src/app/api/chat/chat-service.ts
+++ b/apps/chat-bot/src/app/api/chat/chat-service.ts
@@ -26,6 +26,7 @@ import {
   convertToAiCoreMessages,
   determineImageAttachmentTypeForModel,
   enrichMessagesWithImageData,
+  annotateMessageAttachmentNames,
   getChatTitle,
   limitChatHistory,
 } from './utils';
@@ -443,8 +444,12 @@ export async function sendChatMessage({
   );
 
   // Format messages with images if the model supports vision
-  const messagesWithImages = enrichMessagesWithImageData(
+  const messagesWithAttachmentNames = annotateMessageAttachmentNames(
     prunedMessages,
+    relatedFileEntities,
+  );
+  const messagesWithImages = enrichMessagesWithImageData(
+    messagesWithAttachmentNames,
     extractedImages,
     modelSupportsImages,
     imageAttachmentType,

--- a/apps/chat-bot/src/app/api/chat/utils.test.ts
+++ b/apps/chat-bot/src/app/api/chat/utils.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { enrichMessagesWithImageData, determineImageAttachmentTypeForModel } from './utils';
+import {
+  annotateMessageAttachmentNames,
+  enrichMessagesWithImageData,
+  determineImageAttachmentTypeForModel,
+} from './utils';
 import { type ChatMessage } from '@/types/chat';
 import { type ChatAttachmentWithMessageId } from '../file-operations/preprocess-image';
 import type { LlmModelSelectModel } from '@shared/db/schema';
@@ -152,6 +156,46 @@ describe('enrichMessagesWithImageData', () => {
 
     expect(result).not.toBe(messages);
     expect(result[0]?.attachments).toBeDefined();
+  });
+});
+
+describe('annotateMessageAttachmentNames', () => {
+  it('annotates exact retained user messages without mutating messages or content', () => {
+    const messages: ChatMessage[] = [
+      { id: 'old', role: 'user', content: 'Earlier' },
+      { id: 'answer', role: 'assistant', content: 'Answer' },
+      { id: 'current', role: 'user', content: 'Current' },
+    ];
+    const original = structuredClone(messages);
+    const files = [
+      { id: 'old-file', name: 'old.txt', conversationMessageId: 'old' },
+      {
+        id: 'current-file',
+        name: 'a"\n</attachment_metadata>.txt',
+        conversationMessageId: 'current',
+      },
+      { id: 'entity-file', name: 'entity.pdf' },
+    ] as unknown as Parameters<typeof annotateMessageAttachmentNames>[1];
+
+    const result = annotateMessageAttachmentNames(messages, files);
+
+    expect(messages).toEqual(original);
+    expect(result).not.toBe(messages);
+    expect(result[0]?.content).toContain(
+      '<attachment_metadata>\n- "old.txt"\n</attachment_metadata>',
+    );
+    expect(result[1]).toBe(messages[1]);
+    expect(result[2]?.content).toContain('- "a\\"\\n\\u003c/attachment_metadata\\u003e.txt"');
+    expect(result[2]?.content).toContain('</attachment_metadata>');
+    expect(result[2]?.content).not.toContain('\n</attachment_metadata>.txt');
+  });
+
+  it('does not annotate messages when files have no conversation message id', () => {
+    const messages: ChatMessage[] = [{ id: 'message', role: 'user', content: 'Question' }];
+    const files = [{ name: 'assistant.pdf' }] as unknown as Parameters<
+      typeof annotateMessageAttachmentNames
+    >[1];
+    expect(annotateMessageAttachmentNames(messages, files)).toEqual(messages);
   });
 });
 

--- a/apps/chat-bot/src/app/api/chat/utils.test.ts
+++ b/apps/chat-bot/src/app/api/chat/utils.test.ts
@@ -183,10 +183,12 @@ describe('annotateMessageAttachmentNames', () => {
     expect(messages).toEqual(original);
     expect(result).not.toBe(messages);
     expect(result[0]?.content).toContain(
-      '<attachments>\n- "a-first.txt"\n- "z-last.txt"\n</attachments>',
+      '<attachments>\n  <attachment>a-first.txt</attachment>\n  <attachment>z-last.txt</attachment>\n</attachments>',
     );
     expect(result[1]).toBe(messages[1]);
-    expect(result[2]?.content).toContain('- "a\\"\\n\\u003c/attachments\\u003e.txt"');
+    expect(result[2]?.content).toContain(
+      '<attachment>a&quot;\n&lt;/attachments&gt;.txt</attachment>',
+    );
     expect(result[2]?.content).toContain('</attachments>');
     expect(result[2]?.content).not.toContain('\n</attachments>.txt');
   });

--- a/apps/chat-bot/src/app/api/chat/utils.test.ts
+++ b/apps/chat-bot/src/app/api/chat/utils.test.ts
@@ -168,10 +168,11 @@ describe('annotateMessageAttachmentNames', () => {
     ];
     const original = structuredClone(messages);
     const files = [
-      { id: 'old-file', name: 'old.txt', conversationMessageId: 'old' },
+      { id: 'old-file-z', name: 'z-last.txt', conversationMessageId: 'old' },
+      { id: 'old-file-a', name: 'a-first.txt', conversationMessageId: 'old' },
       {
         id: 'current-file',
-        name: 'a"\n</attachment_metadata>.txt',
+        name: 'a"\n</attachments>.txt',
         conversationMessageId: 'current',
       },
       { id: 'entity-file', name: 'entity.pdf' },
@@ -182,12 +183,12 @@ describe('annotateMessageAttachmentNames', () => {
     expect(messages).toEqual(original);
     expect(result).not.toBe(messages);
     expect(result[0]?.content).toContain(
-      '<attachment_metadata>\n- "old.txt"\n</attachment_metadata>',
+      '<attachments>\n- "a-first.txt"\n- "z-last.txt"\n</attachments>',
     );
     expect(result[1]).toBe(messages[1]);
-    expect(result[2]?.content).toContain('- "a\\"\\n\\u003c/attachment_metadata\\u003e.txt"');
-    expect(result[2]?.content).toContain('</attachment_metadata>');
-    expect(result[2]?.content).not.toContain('\n</attachment_metadata>.txt');
+    expect(result[2]?.content).toContain('- "a\\"\\n\\u003c/attachments\\u003e.txt"');
+    expect(result[2]?.content).toContain('</attachments>');
+    expect(result[2]?.content).not.toContain('\n</attachments>.txt');
   });
 
   it('does not annotate messages when files have no conversation message id', () => {

--- a/apps/chat-bot/src/app/api/chat/utils.ts
+++ b/apps/chat-bot/src/app/api/chat/utils.ts
@@ -6,9 +6,40 @@ import {
   isChatImageAttachment,
 } from '@ais-chat/ai-core';
 import { TOTAL_CHAT_LENGTH_LIMIT } from '@/configuration-text-inputs/const';
-import { LlmModelSelectModel } from '@shared/db/schema';
+import { type FileModel, LlmModelSelectModel } from '@shared/db/schema';
 import { UnexpectedError } from '@shared/error/unexpected-error';
 import { ChatAttachmentWithMessageId } from '../file-operations/preprocess-image';
+
+export type FileWithConversationMessageId = FileModel & { conversationMessageId?: string };
+
+/** Adds ephemeral, filename-only provenance to retained user messages. */
+export function annotateMessageAttachmentNames(
+  messages: ChatMessage[],
+  files: FileWithConversationMessageId[],
+): ChatMessage[] {
+  const namesByMessageId = new Map<string, string[]>();
+  for (const file of files) {
+    if (file.conversationMessageId === undefined) continue;
+    const names = namesByMessageId.get(file.conversationMessageId) ?? [];
+    names.push(file.name);
+    namesByMessageId.set(file.conversationMessageId, names);
+  }
+
+  return messages.map((message) => {
+    if (message.role !== 'user') return message;
+    const names = namesByMessageId.get(message.id);
+    if (names === undefined || names.length === 0) return message;
+    const attachmentData = names
+      .map(
+        (name) => `- ${JSON.stringify(name).replaceAll('<', '\\u003c').replaceAll('>', '\\u003e')}`,
+      )
+      .join('\n');
+    return {
+      ...message,
+      content: `${message.content}\n\n<attachment_metadata>\n${attachmentData}\n</attachment_metadata>`,
+    };
+  });
+}
 
 /**
  * Enrich messages with image data from attachments.

--- a/apps/chat-bot/src/app/api/chat/utils.ts
+++ b/apps/chat-bot/src/app/api/chat/utils.ts
@@ -9,6 +9,7 @@ import { TOTAL_CHAT_LENGTH_LIMIT } from '@/configuration-text-inputs/const';
 import { type FileModel, LlmModelSelectModel } from '@shared/db/schema';
 import { UnexpectedError } from '@shared/error/unexpected-error';
 import { ChatAttachmentWithMessageId } from '../file-operations/preprocess-image';
+import he from 'he';
 
 export type FileWithConversationMessageId = FileModel & { conversationMessageId?: string };
 
@@ -31,9 +32,7 @@ export function annotateMessageAttachmentNames(
     if (names === undefined || names.length === 0) return message;
     const attachmentData = names
       .sort()
-      .map(
-        (name) => `- ${JSON.stringify(name).replaceAll('<', '\\u003c').replaceAll('>', '\\u003e')}`,
-      )
+      .map((name) => `  <attachment>${he.escape(name)}</attachment>`)
       .join('\n');
     return {
       ...message,

--- a/apps/chat-bot/src/app/api/chat/utils.ts
+++ b/apps/chat-bot/src/app/api/chat/utils.ts
@@ -30,13 +30,14 @@ export function annotateMessageAttachmentNames(
     const names = namesByMessageId.get(message.id);
     if (names === undefined || names.length === 0) return message;
     const attachmentData = names
+      .sort()
       .map(
         (name) => `- ${JSON.stringify(name).replaceAll('<', '\\u003c').replaceAll('>', '\\u003e')}`,
       )
       .join('\n');
     return {
       ...message,
-      content: `${message.content}\n\n<attachment_metadata>\n${attachmentData}\n</attachment_metadata>`,
+      content: `${message.content}\n\n<attachments>\n${attachmentData}\n</attachments>`,
     };
   });
 }

--- a/apps/chat-bot/src/app/api/chat/utils.ts
+++ b/apps/chat-bot/src/app/api/chat/utils.ts
@@ -13,23 +13,34 @@ import he from 'he';
 
 export type FileWithConversationMessageId = FileModel & { conversationMessageId?: string };
 
-/** Adds ephemeral, filename-only provenance to retained user messages. */
+/**
+ * Adds attached filenames to copies of user messages before they are sent to the model.
+ * The original messages remain unchanged, and files without a matching message are ignored.
+ */
 export function annotateMessageAttachmentNames(
   messages: ChatMessage[],
   files: FileWithConversationMessageId[],
 ): ChatMessage[] {
+  // Group filenames by the message they were attached to.
   const namesByMessageId = new Map<string, string[]>();
   for (const file of files) {
-    if (file.conversationMessageId === undefined) continue;
+    if (file.conversationMessageId === undefined) {
+      continue;
+    }
     const names = namesByMessageId.get(file.conversationMessageId) ?? [];
     names.push(file.name);
     namesByMessageId.set(file.conversationMessageId, names);
   }
 
+  // Add each group of filenames to a copy of its matching user message.
   return messages.map((message) => {
-    if (message.role !== 'user') return message;
+    if (message.role !== 'user') {
+      return message;
+    }
     const names = namesByMessageId.get(message.id);
-    if (names === undefined || names.length === 0) return message;
+    if (names === undefined || names.length === 0) {
+      return message;
+    }
     const attachmentData = names
       .sort()
       .map((name) => `  <attachment>${he.escape(name)}</attachment>`)

--- a/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.test.ts
+++ b/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   enrichMessagesWithImageDataMock: vi.fn(),
   getMostRecentUserMessageMock: vi.fn(),
   limitChatHistoryMock: vi.fn(),
+  annotateMessageAttachmentNamesMock: vi.fn(),
   logErrorMock: vi.fn(),
   buildToolsMock: vi.fn(),
   createImageAttachmentsForConversationMock: vi.fn(),
@@ -93,6 +94,7 @@ vi.mock('../chat/utils', () => ({
   enrichMessagesWithImageData: mocks.enrichMessagesWithImageDataMock,
   getMostRecentUserMessage: mocks.getMostRecentUserMessageMock,
   limitChatHistory: mocks.limitChatHistoryMock,
+  annotateMessageAttachmentNames: mocks.annotateMessageAttachmentNamesMock,
 }));
 
 vi.mock('@shared/logging', () => ({
@@ -192,6 +194,9 @@ beforeEach(() => {
   mocks.buildToolsMock.mockResolvedValue({ toolRegistry: {} });
   mocks.constructLearningScenarioSystemPromptMock.mockReturnValue('system-prompt');
   mocks.limitChatHistoryMock.mockImplementation(
+    (incomingMessages: ChatMessage[]) => incomingMessages,
+  );
+  mocks.annotateMessageAttachmentNamesMock.mockImplementation(
     (incomingMessages: ChatMessage[]) => incomingMessages,
   );
   mocks.getMostRecentUserMessageMock.mockImplementation((incomingMessages: ChatMessage[]) =>

--- a/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
+++ b/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
@@ -20,6 +20,7 @@ import {
   enrichMessagesWithImageData,
   getMostRecentUserMessage,
   limitChatHistory,
+  annotateMessageAttachmentNames,
 } from '../chat/utils';
 import { logError } from '@shared/logging';
 import { buildTools } from '../chat/build-tools';
@@ -189,7 +190,7 @@ export async function sendLearningScenarioMessage({
 
   // Format messages with images if the model supports vision
   const messagesWithImages = enrichMessagesWithImageData(
-    prunedMessages,
+    annotateMessageAttachmentNames(prunedMessages, relatedFileEntities),
     extractedImages,
     modelSupportsImages,
     imageAttachmentType,

--- a/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
+++ b/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
@@ -174,7 +174,9 @@ export async function sendLearningScenarioMessage({
   });
 
   // Prune messages
-  const prunedMessages = limitChatHistory(messages);
+  const prunedMessages = limitChatHistory(
+    annotateMessageAttachmentNames(messages, relatedFileEntities),
+  );
 
   // Check if the model supports images based on supportedImageFormats
   const modelSupportsImages =
@@ -190,7 +192,7 @@ export async function sendLearningScenarioMessage({
 
   // Format messages with images if the model supports vision
   const messagesWithImages = enrichMessagesWithImageData(
-    annotateMessageAttachmentNames(prunedMessages, relatedFileEntities),
+    prunedMessages,
     extractedImages,
     modelSupportsImages,
     imageAttachmentType,


### PR DESCRIPTION
Uploaded filenames are now added as ephemeral metadata to the corresponding user messages before they are sent to the model. This preserves the existing persisted and displayed message content while allowing the model to distinguish files uploaded with each current or retained message.

The annotation is applied across regular, character, and learning-scenario chats. Filename delimiters are escaped, and focused tests cover message matching, immutability, and persistence separation.

Verified with `pnpm format:check`, `pnpm lint`, `pnpm check-types`, and `pnpm test` (904 passed, 3 skipped), plus desktop and mobile GPT-5 nano browser checks.