### PR TITLE
TD-1548: Stop retaining scraped response bodies and JSDOM windows

### DIFF
--- a/apps/chat-bot/src/app/api/web-scraper/web-scraper-readability.ts
+++ b/apps/chat-bot/src/app/api/web-scraper/web-scraper-readability.ts
@@ -13,6 +13,11 @@ const headers = {
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36',
 };
 
+// An unread response body keeps its stream and internal buffers alive for the lifetime of the process.
+function discardBody(response: Response): void {
+  response.body?.cancel().catch(() => {});
+}
+
 /**
  * Checks if the URL is valid and then fetches the main content of the website.
  * Uses Mozilla's Readability to extract the main content.
@@ -45,18 +50,26 @@ export async function webScraperReadability(url: string): Promise<WebSource> {
   }
 
   if (!response.ok) {
+    discardBody(response);
     return defaultErrorSource(url);
   }
 
-  const buffer = Buffer.from(await response.clone().arrayBuffer());
+  let buffer: Buffer;
+  try {
+    buffer = Buffer.from(await response.arrayBuffer());
+  } catch (error) {
+    logError(`Failed to read response body for URL: ${url}`, error);
+    return defaultErrorSource(url);
+  }
+
   const isBinary = await isBinaryFile(buffer);
   if (isBinary) {
     logInfo(`Detected binary content for URL: ${url}`);
     return defaultErrorSource(url);
   }
 
-  // Extract title
-  const html = await response.clone().text();
+  // Matches Response.text(), which always decodes as UTF-8 regardless of the charset header
+  const html = new TextDecoder().decode(buffer);
   // Extract title from meta tags or Open Graph tags first, as they're more reliable
   const ogTitleMatch = html.match(/<meta[^>]*property="og:title"[^>]*content="([^"]*)"/i);
   const metaTitleMatch = html.match(/<meta[^>]*name="title"[^>]*content="([^"]*)"/i);
@@ -114,6 +127,8 @@ function extractArticleContent(html: string, url: string): string {
   } catch (error) {
     logError(`Error extracting content with Readability for URL: ${url}`, error);
     return '';
+  } finally {
+    doc?.window.close();
   }
 }
 
@@ -129,6 +144,7 @@ export async function isWebPage(url: string, timeout: number) {
     method: 'HEAD',
     signal: AbortSignal.timeout(timeout),
   });
+  discardBody(response);
 
   const contentType = response.headers.get('content-type');
 

--- a/apps/chat-bot/src/app/api/web-scraper/web-scraper-readability.ts
+++ b/apps/chat-bot/src/app/api/web-scraper/web-scraper-readability.ts
@@ -15,7 +15,7 @@ const headers = {
 
 // An unread response body keeps its stream and internal buffers alive for the lifetime of the process.
 function discardBody(response: Response): void {
-  response.body?.cancel().catch(() => {});
+  response.body?.cancel().catch(() => undefined);
 }
 
 /**


### PR DESCRIPTION
Part 1 of 3 investigating the production memory growth in TD-1548. Independent of the other two — reviewable and mergeable on its own.

Production pods were accumulating ~1.3 GB of `arrayBuffers` between deployments. Instrumentation in the gitops repo narrowed it to ~22,700 live `ReadableStream` objects, about 8,000 of which were never consumed or cancelled. This is that group.

The readability scraper called `response.clone()` twice. Cloning tees the body stream, and the original `response.body` was never read or cancelled, so undici buffered the entire page for the lifetime of the process — one full page body retained per scrape.

The body is now read once and both the binary check and the HTML derive from that single buffer. Decoding uses `TextDecoder` rather than `buffer.toString('utf8')` to match `Response.text()`, which per the fetch spec always decodes as UTF-8 and strips a BOM, so behaviour is unchanged. Bodies are explicitly cancelled on the paths that abandon them (the HEAD probe, and the non-ok early return).

Also closes the JSDOM window after parsing. That is a separate leak of a different resource — the heap was stable, so it is not part of the 1.3 GB — but the unused `let doc` declaration suggested the cleanup had been dropped at some point, and the fix is two lines.