### PR TITLE
TD-1548: Abort LLM generation when it is no longer needed

### DIFF
--- a/apps/chat-bot/src/app/api/character/character-chat-service.ts
+++ b/apps/chat-bot/src/app/api/character/character-chat-service.ts
@@ -136,7 +136,7 @@ export async function sendCharacterMessage({
     federalStateId: teacherUserAndContext.federalState.id,
   });
 
-  const { stream, update, done, error: streamError } = createTextStream();
+  const { stream, signal: generationSignal, update, done, error: streamError } = createTextStream();
   const assistantMessageId = crypto.randomUUID();
 
   const allowWebTools = isWebSearchEnabledForEntity({
@@ -201,6 +201,7 @@ export async function sendCharacterMessage({
     messages: convertToAiCoreMessages(systemPrompt, messagesWithImages),
     toolRegistry: tools.toolRegistry,
     agentName: resolveAgentNameForTracing({ characterId: character.id }),
+    abortSignal: generationSignal,
     onTextChunk: (delta) => {
       update(delta);
     },

--- a/apps/chat-bot/src/app/api/chat/chat-service.ts
+++ b/apps/chat-bot/src/app/api/chat/chat-service.ts
@@ -417,7 +417,7 @@ export async function sendChatMessage({
       activeAssistant ?? { isWebSearchEnabled: true },
   });
 
-  const { stream, update, done, error: streamError } = createTextStream();
+  const { stream, signal: generationSignal, update, done, error: streamError } = createTextStream();
 
   const tools = await buildTools({
     user,
@@ -592,6 +592,7 @@ export async function sendChatMessage({
     messages: convertToAiCoreMessages(systemPrompt, messagesWithImages),
     toolRegistry: tools.toolRegistry,
     agentName: resolveAgentNameForTracing({ characterId, learningScenarioId, assistantId }),
+    abortSignal: generationSignal,
     onTextChunk: (delta: string) => {
       update(delta);
     },

--- a/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
+++ b/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
@@ -141,7 +141,7 @@ export async function sendLearningScenarioMessage({
     federalStateId: teacherUserAndContext.federalState.id,
   });
 
-  const { stream, update, done, error: streamError } = createTextStream();
+  const { stream, signal: generationSignal, update, done, error: streamError } = createTextStream();
   const assistantMessageId = crypto.randomUUID();
 
   const allowWebTools = isWebSearchEnabledForEntity({
@@ -206,6 +206,7 @@ export async function sendLearningScenarioMessage({
     messages: convertToAiCoreMessages(systemPrompt, messagesWithImages),
     toolRegistry: tools.toolRegistry,
     agentName: resolveAgentNameForTracing({ learningScenarioId: learningScenario.id }),
+    abortSignal: generationSignal,
     onTextChunk: (delta) => {
       update(delta);
     },

--- a/apps/chat-bot/src/utils/streaming.test.ts
+++ b/apps/chat-bot/src/utils/streaming.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { ChatStreamEvent } from './streaming';
-import { createTextStream, decodeChatStreamEvent, encodeChatStreamEvent } from './streaming';
+import {
+  createTextStream,
+  decodeChatStreamEvent,
+  encodeChatStreamEvent,
+  readTextStream,
+} from './streaming';
 
 vi.mock('@shared/logging', () => ({
   logError: vi.fn(),
@@ -78,5 +83,36 @@ describe('createTextStream', () => {
       done();
       error(new Error('ignored'));
     }).not.toThrow();
+  });
+});
+
+describe('readTextStream', () => {
+  it('aborts the signal when the consumer stops reading early', async () => {
+    const { stream, signal, update } = createTextStream();
+
+    update('first');
+    update('second');
+
+    for await (const chunk of readTextStream(stream)) {
+      expect(chunk).toBe('first');
+      break;
+    }
+
+    expect(signal.aborted).toBe(true);
+  });
+
+  it('leaves the signal untouched when the producer completes normally', async () => {
+    const { stream, signal, update, done } = createTextStream();
+
+    update('all done');
+    done();
+
+    const chunks: string[] = [];
+    for await (const chunk of readTextStream(stream)) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(['all done']);
+    expect(signal.aborted).toBe(false);
   });
 });

--- a/apps/chat-bot/src/utils/streaming.test.ts
+++ b/apps/chat-bot/src/utils/streaming.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ChatStreamEvent } from './streaming';
+import { createTextStream, decodeChatStreamEvent, encodeChatStreamEvent } from './streaming';
+
+vi.mock('@shared/logging', () => ({
+  logError: vi.fn(),
+}));
+
+describe('encodeChatStreamEvent / decodeChatStreamEvent', () => {
+  it('round-trips a web search result event', () => {
+    const event: ChatStreamEvent = {
+      type: 'web_search_results',
+      webSearchResults: [
+        {
+          type: 'text',
+          name: 'Example',
+          url: 'https://example.com',
+          content: 'Example content',
+          favicon: 'https://example.com/favicon.ico',
+        },
+      ],
+    };
+
+    expect(decodeChatStreamEvent(encodeChatStreamEvent(event))).toEqual(event);
+  });
+
+  it('returns null for plain text chunks and malformed events', () => {
+    expect(decodeChatStreamEvent('just some streamed text')).toBeNull();
+    expect(decodeChatStreamEvent('\u001enot json')).toBeNull();
+    expect(decodeChatStreamEvent('\u001e{"type":"something_else"}')).toBeNull();
+  });
+});
+
+describe('createTextStream', () => {
+  it('streams updates to the consumer until done', async () => {
+    const { stream, update, done } = createTextStream();
+
+    update('Hello ');
+    update('world.');
+    done();
+
+    const chunks: string[] = [];
+    for await (const chunk of stream as unknown as AsyncIterable<string>) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.join('')).toBe('Hello world.');
+  });
+
+  it('does not abort the signal while the consumer is still reading', () => {
+    const { signal, update, done } = createTextStream();
+
+    update('Hello');
+    done();
+
+    expect(signal.aborted).toBe(false);
+  });
+
+  it('aborts the signal when the consumer cancels the stream', async () => {
+    const { stream, signal, update } = createTextStream();
+
+    update('Partial');
+    expect(signal.aborted).toBe(false);
+
+    await stream.cancel();
+
+    expect(signal.aborted).toBe(true);
+    expect(signal.reason).toBeInstanceOf(Error);
+  });
+
+  it('ignores further producer calls after the consumer cancelled', async () => {
+    const { stream, update, done, error } = createTextStream();
+
+    await stream.cancel();
+
+    expect(() => {
+      update('ignored');
+      done();
+      error(new Error('ignored'));
+    }).not.toThrow();
+  });
+});

--- a/apps/chat-bot/src/utils/streaming.ts
+++ b/apps/chat-bot/src/utils/streaming.ts
@@ -38,15 +38,20 @@ export function decodeChatStreamEvent(chunk: string): ChatStreamEvent | null {
 /**
  * Creates a streamable text value for Server Actions.
  * Returns a controller to update/complete the stream and a ReadableStream to consume.
+ *
+ * `signal` aborts once the consumer disappears, so the producer can tear down its own
+ * upstream work instead of generating into a stream nobody reads.
  */
 export function createTextStream(): {
   stream: ReadableStream<string>;
+  signal: AbortSignal;
   update: (text: string) => void;
   done: () => void;
   error: (err: Error) => void;
 } {
   let controller: ReadableStreamDefaultController<string>;
   let cancelledByConsumer = false;
+  const abortController = new AbortController();
 
   const stream = new ReadableStream<string>({
     start(c) {
@@ -55,11 +60,13 @@ export function createTextStream(): {
     cancel() {
       // Consumer canceled the stream (e.g., user reloaded or closed the tab)
       cancelledByConsumer = true;
+      abortController.abort(new Error('consumer cancelled the stream'));
     },
   });
 
   return {
     stream,
+    signal: abortController.signal,
     update: (text: string) => {
       if (cancelledByConsumer) return;
       try {

--- a/apps/chat-bot/src/utils/streaming.ts
+++ b/apps/chat-bot/src/utils/streaming.ts
@@ -115,6 +115,8 @@ export async function* readTextStream(
       }
     }
   } finally {
+    // Cancels only when the stream is still readable, so an abandoned stream reaches its producer.
+    await reader.cancel().catch(() => undefined);
     reader.releaseLock();
   }
 }

--- a/packages/ai-core/src/chat/agent-loop.test.ts
+++ b/packages/ai-core/src/chat/agent-loop.test.ts
@@ -24,6 +24,9 @@ describe('agent-loop', () => {
     totalTokens: 30,
   };
 
+  // Lets the fire-and-forget loop settle so "callback was never called" assertions are reliable.
+  const flushAsync = () => new Promise((resolve) => setTimeout(resolve, 10));
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -582,6 +585,190 @@ describe('agent-loop', () => {
 
       expect(agentSpanCalls).toHaveLength(1);
       expect(toolSpanCalls).toHaveLength(2);
+    });
+  });
+
+  describe('abortSignal', () => {
+    it('forwards the signal to the stream with and without tools', async () => {
+      const messages: Message[] = [{ role: 'user', content: 'Test query' }];
+      const abortController = new AbortController();
+
+      mockGenerateAgenticStreamWithBilling.mockImplementation(async function* () {
+        yield { type: 'text', delta: 'Response.' } satisfies StreamEvent;
+        yield { type: 'finish', usage } satisfies StreamEvent;
+      });
+
+      const toolRegistry = {
+        test_tool: {
+          definition: { name: 'test_tool', description: 'Test', parameters: {} },
+          handler: async () => 'tool result',
+        },
+      };
+
+      const onComplete = vi.fn();
+
+      runAgentLoop({
+        modelSelection: { modelIds: ['test-model'], modelName: 'Test Model' },
+        apiKeyId: 'test-key',
+        messages,
+        toolRegistry,
+        agentName: 'Test Agent',
+        abortSignal: abortController.signal,
+        onTextChunk: vi.fn(),
+        onComplete,
+        onError: vi.fn(),
+      });
+
+      await vi.waitFor(() => {
+        expect(onComplete).toHaveBeenCalled();
+      });
+
+      expect(mockGenerateAgenticStreamWithBilling).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'test-key',
+        expect.any(Function),
+        expect.objectContaining({ tools: expect.anything(), abortSignal: abortController.signal }),
+      );
+
+      mockGenerateAgenticStreamWithBilling.mockClear();
+      const onCompleteWithoutTools = vi.fn();
+
+      runAgentLoop({
+        modelSelection: { modelIds: ['test-model'], modelName: 'Test Model' },
+        apiKeyId: 'test-key',
+        messages,
+        agentName: 'Test Agent',
+        abortSignal: abortController.signal,
+        onTextChunk: vi.fn(),
+        onComplete: onCompleteWithoutTools,
+        onError: vi.fn(),
+      });
+
+      await vi.waitFor(() => {
+        expect(onCompleteWithoutTools).toHaveBeenCalled();
+      });
+
+      expect(mockGenerateAgenticStreamWithBilling).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'test-key',
+        expect.any(Function),
+        { abortSignal: abortController.signal },
+      );
+    });
+
+    it('stops before the next iteration once aborted and keeps the partial text', async () => {
+      const messages: Message[] = [{ role: 'user', content: 'Test query' }];
+      const onTextChunk = vi.fn();
+      const onComplete = vi.fn();
+      const onError = vi.fn();
+      const abortController = new AbortController();
+
+      mockGenerateAgenticStreamWithBilling.mockImplementation(async function* () {
+        yield { type: 'text', delta: 'Partial answer.' } satisfies StreamEvent;
+        yield {
+          type: 'tool_call',
+          call: { id: 'call_123', name: 'test_tool', arguments: '{}' },
+        } satisfies StreamEvent;
+        yield { type: 'finish', usage } satisfies StreamEvent;
+      });
+
+      const toolRegistry = {
+        test_tool: {
+          definition: { name: 'test_tool', description: 'Test', parameters: {} },
+          handler: async () => {
+            abortController.abort();
+            return 'tool result';
+          },
+        },
+      };
+
+      runAgentLoop({
+        modelSelection: { modelIds: ['test-model'], modelName: 'Test Model' },
+        apiKeyId: 'test-key',
+        messages,
+        toolRegistry,
+        agentName: 'Test Agent',
+        abortSignal: abortController.signal,
+        onTextChunk,
+        onComplete,
+        onError,
+      });
+
+      await vi.waitFor(() => {
+        expect(onComplete).toHaveBeenCalled();
+      });
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(mockGenerateAgenticStreamWithBilling).toHaveBeenCalledTimes(1);
+      expect(onComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ fullText: 'Partial answer.' }),
+      );
+    });
+
+    it('does not report an EmptyResponseError when aborted before any text', async () => {
+      const messages: Message[] = [{ role: 'user', content: 'Test query' }];
+      const onComplete = vi.fn();
+      const onError = vi.fn();
+      const abortController = new AbortController();
+      abortController.abort();
+
+      mockGenerateAgenticStreamWithBilling.mockImplementation(async function* () {
+        yield { type: 'finish', usage } satisfies StreamEvent;
+      });
+
+      runAgentLoop({
+        modelSelection: { modelIds: ['test-model'], modelName: 'Test Model' },
+        apiKeyId: 'test-key',
+        messages,
+        agentName: 'Test Agent',
+        abortSignal: abortController.signal,
+        onTextChunk: vi.fn(),
+        onComplete,
+        onError,
+      });
+
+      await vi.waitFor(() => {
+        expect(mockStartSpan).toHaveBeenCalled();
+      });
+      await flushAsync();
+
+      expect(mockGenerateAgenticStreamWithBilling).not.toHaveBeenCalled();
+      expect(onError).not.toHaveBeenCalled();
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it('swallows stream errors that are caused by the abort', async () => {
+      const messages: Message[] = [{ role: 'user', content: 'Test query' }];
+      const onComplete = vi.fn();
+      const onError = vi.fn();
+      const abortController = new AbortController();
+
+      mockGenerateAgenticStreamWithBilling.mockImplementation(async function* () {
+        yield { type: 'text', delta: 'Partial.' } satisfies StreamEvent;
+        abortController.abort();
+        throw new Error('The operation was aborted');
+      });
+
+      runAgentLoop({
+        modelSelection: { modelIds: ['test-model'], modelName: 'Test Model' },
+        apiKeyId: 'test-key',
+        messages,
+        agentName: 'Test Agent',
+        abortSignal: abortController.signal,
+        onTextChunk: vi.fn(),
+        onComplete,
+        onError,
+      });
+
+      await vi.waitFor(() => {
+        expect(abortController.signal.aborted).toBe(true);
+      });
+      await flushAsync();
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(onComplete).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/ai-core/src/chat/agent-loop.test.ts
+++ b/packages/ai-core/src/chat/agent-loop.test.ts
@@ -739,7 +739,7 @@ describe('agent-loop', () => {
       expect(onComplete).not.toHaveBeenCalled();
     });
 
-    it('swallows stream errors that are caused by the abort', async () => {
+    it('keeps the partial text when the stream throws because of the abort', async () => {
       const messages: Message[] = [{ role: 'user', content: 'Test query' }];
       const onComplete = vi.fn();
       const onError = vi.fn();
@@ -749,6 +749,39 @@ describe('agent-loop', () => {
         yield { type: 'text', delta: 'Partial.' } satisfies StreamEvent;
         abortController.abort();
         throw new Error('The operation was aborted');
+      });
+
+      runAgentLoop({
+        modelSelection: { modelIds: ['test-model'], modelName: 'Test Model' },
+        apiKeyId: 'test-key',
+        messages,
+        agentName: 'Test Agent',
+        abortSignal: abortController.signal,
+        onTextChunk: vi.fn(),
+        onComplete,
+        onError,
+      });
+
+      await vi.waitFor(() => {
+        expect(onComplete).toHaveBeenCalled();
+      });
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({ fullText: 'Partial.' }));
+    });
+
+    it('reports nothing when the stream throws after an abort without any text', async () => {
+      const messages: Message[] = [{ role: 'user', content: 'Test query' }];
+      const onComplete = vi.fn();
+      const onError = vi.fn();
+      const abortController = new AbortController();
+
+      mockGenerateAgenticStreamWithBilling.mockImplementation(async function* () {
+        abortController.abort();
+        if (abortController.signal.aborted) {
+          throw new Error('The operation was aborted');
+        }
+        yield { type: 'finish', usage } satisfies StreamEvent;
       });
 
       runAgentLoop({

--- a/packages/ai-core/src/chat/agent-loop.test.ts
+++ b/packages/ai-core/src/chat/agent-loop.test.ts
@@ -739,6 +739,52 @@ describe('agent-loop', () => {
       expect(onComplete).not.toHaveBeenCalled();
     });
 
+    it('does not run tool handlers when the abort lands before tool execution', async () => {
+      const messages: Message[] = [{ role: 'user', content: 'Test query' }];
+      const onComplete = vi.fn();
+      const onError = vi.fn();
+      const abortController = new AbortController();
+      const handler = vi.fn(async () => 'tool result');
+
+      mockGenerateAgenticStreamWithBilling.mockImplementation(async function* () {
+        yield { type: 'text', delta: 'Partial answer.' } satisfies StreamEvent;
+        yield {
+          type: 'tool_call',
+          call: { id: 'call_123', name: 'test_tool', arguments: '{}' },
+        } satisfies StreamEvent;
+        abortController.abort();
+        yield { type: 'finish', usage } satisfies StreamEvent;
+      });
+
+      runAgentLoop({
+        modelSelection: { modelIds: ['test-model'], modelName: 'Test Model' },
+        apiKeyId: 'test-key',
+        messages,
+        toolRegistry: {
+          test_tool: {
+            definition: { name: 'test_tool', description: 'Test', parameters: {} },
+            handler,
+          },
+        },
+        agentName: 'Test Agent',
+        abortSignal: abortController.signal,
+        onTextChunk: vi.fn(),
+        onComplete,
+        onError,
+      });
+
+      await vi.waitFor(() => {
+        expect(onComplete).toHaveBeenCalled();
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(mockGenerateAgenticStreamWithBilling).toHaveBeenCalledTimes(1);
+      expect(onError).not.toHaveBeenCalled();
+      expect(onComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ fullText: 'Partial answer.' }),
+      );
+    });
+
     it('keeps the partial text when the stream throws because of the abort', async () => {
       const messages: Message[] = [{ role: 'user', content: 'Test query' }];
       const onComplete = vi.fn();

--- a/packages/ai-core/src/chat/agent-loop.ts
+++ b/packages/ai-core/src/chat/agent-loop.ts
@@ -29,6 +29,8 @@ type RunAgentLoopParams = {
   messages: AiCoreMessage[];
   toolRegistry?: ToolRegistry;
   agentName: string;
+  /** Tears down the upstream provider stream when the client goes away or the generation times out. */
+  abortSignal?: AbortSignal;
   onTextChunk: (delta: string) => void;
   onComplete: (result: {
     fullText: string;
@@ -47,6 +49,7 @@ export function runAgentLoop({
   messages,
   toolRegistry,
   agentName,
+  abortSignal,
   onTextChunk,
   onComplete,
   onError,
@@ -76,6 +79,10 @@ export function runAgentLoop({
         },
         async (agentSpan) => {
           for (let iteration = 0; iteration < MAX_AGENTIC_ITERATIONS; iteration++) {
+            if (abortSignal?.aborted) {
+              break;
+            }
+
             const pendingToolCalls: ToolCall[] = [];
             const overBudgetToolCalls: ToolCall[] = [];
             let iterationText = '';
@@ -102,7 +109,9 @@ export function runAgentLoop({
                 };
                 totalPriceInCents += priceInCents;
               },
-              tools.length > 0 && !isLastIteration ? { tools, toolChoice: 'auto' } : undefined,
+              tools.length > 0 && !isLastIteration
+                ? { tools, toolChoice: 'auto', abortSignal }
+                : { abortSignal },
             );
 
             for await (const event of stream) {
@@ -197,7 +206,10 @@ export function runAgentLoop({
       );
 
       if (fullText.trim().length === 0) {
-        onError(new EmptyResponseError({ modelId: lastModelId }));
+        // An abort before any output is a teardown, not an empty-response failure.
+        if (!abortSignal?.aborted) {
+          onError(new EmptyResponseError({ modelId: lastModelId }));
+        }
         return;
       }
 
@@ -210,6 +222,10 @@ export function runAgentLoop({
         agentLoopMessages: loopMessages.slice(messages.length),
       });
     } catch (error) {
+      // An aborted generation is an expected teardown, not a failure to report.
+      if (abortSignal?.aborted) {
+        return;
+      }
       logError('Error during agent loop:', error);
       onError(error instanceof Error ? error : new Error('Unknown error'));
     }

--- a/packages/ai-core/src/chat/agent-loop.ts
+++ b/packages/ai-core/src/chat/agent-loop.ts
@@ -65,6 +65,16 @@ export function runAgentLoop({
     const loopMessages = [...messages];
     const tools = toolRegistry ? Object.values(toolRegistry).map((entry) => entry.definition) : [];
 
+    const complete = () =>
+      onComplete({
+        fullText,
+        usage: totalUsage,
+        priceInCents: totalPriceInCents,
+        modelId: lastModelId,
+        modelUsages,
+        agentLoopMessages: loopMessages.slice(messages.length),
+      });
+
     try {
       await Sentry.startSpan(
         {
@@ -114,23 +124,26 @@ export function runAgentLoop({
                 : { abortSignal },
             );
 
-            for await (const event of stream) {
-              if (event.type === 'text') {
-                iterationText += event.delta;
-                onTextChunk(event.delta);
-              } else if (event.type === 'tool_call') {
-                if (pendingToolCalls.length < MAX_TOOL_CALLS_PER_ITERATION) {
-                  // On last iteration, tools are disabled but model might still emit tool calls
-                  if (!isLastIteration) {
-                    pendingToolCalls.push(event.call);
+            try {
+              for await (const event of stream) {
+                if (event.type === 'text') {
+                  iterationText += event.delta;
+                  onTextChunk(event.delta);
+                } else if (event.type === 'tool_call') {
+                  if (pendingToolCalls.length < MAX_TOOL_CALLS_PER_ITERATION) {
+                    // On last iteration, tools are disabled but model might still emit tool calls
+                    if (!isLastIteration) {
+                      pendingToolCalls.push(event.call);
+                    }
+                  } else {
+                    overBudgetToolCalls.push(event.call);
                   }
-                } else {
-                  overBudgetToolCalls.push(event.call);
                 }
               }
+            } finally {
+              // An interrupted stream still produced text; keep it instead of discarding it.
+              fullText += iterationText;
             }
-
-            fullText += iterationText;
 
             if (pendingToolCalls.length === 0 && overBudgetToolCalls.length === 0) {
               break;
@@ -213,17 +226,15 @@ export function runAgentLoop({
         return;
       }
 
-      onComplete({
-        fullText,
-        usage: totalUsage,
-        priceInCents: totalPriceInCents,
-        modelId: lastModelId,
-        modelUsages,
-        agentLoopMessages: loopMessages.slice(messages.length),
-      });
+      complete();
     } catch (error) {
-      // An aborted generation is an expected teardown, not a failure to report.
+      // An aborted generation is an expected teardown, not a failure to report, but whatever
+      // was already generated must still reach the caller so it can be persisted.
       if (abortSignal?.aborted) {
+        logError('Agent loop aborted:', error);
+        if (fullText.trim().length > 0) {
+          complete();
+        }
         return;
       }
       logError('Error during agent loop:', error);

--- a/packages/ai-core/src/chat/agent-loop.ts
+++ b/packages/ai-core/src/chat/agent-loop.ts
@@ -149,6 +149,10 @@ export function runAgentLoop({
               break;
             }
 
+            if (abortSignal?.aborted) {
+              break;
+            }
+
             loopMessages.push({
               role: 'assistant',
               content: iterationText,

--- a/packages/ai-core/src/chat/agent-loop.ts
+++ b/packages/ai-core/src/chat/agent-loop.ts
@@ -235,7 +235,6 @@ export function runAgentLoop({
       // An aborted generation is an expected teardown, not a failure to report, but whatever
       // was already generated must still reach the caller so it can be persisted.
       if (abortSignal?.aborted) {
-        logError('Agent loop aborted:', error);
         if (fullText.trim().length > 0) {
           complete();
         }

--- a/packages/ai-core/src/chat/providers/azure.ts
+++ b/packages/ai-core/src/chat/providers/azure.ts
@@ -92,7 +92,13 @@ export function constructAzureResponsesStreamFn(model: AiModel): TextStreamFn {
 export function constructAzureResponsesAgenticStreamFn(model: AiModel): AgenticStreamFn {
   const { client, deployment } = createAzureClient(model);
 
-  return async function* getAzureTextStream({ messages, maxTokens, tools, toolChoice }) {
+  return async function* getAzureTextStream({
+    messages,
+    maxTokens,
+    tools,
+    toolChoice,
+    abortSignal,
+  }) {
     yield* streamOpenAICompatibleAgenticResponse({
       client,
       messages,
@@ -100,6 +106,7 @@ export function constructAzureResponsesAgenticStreamFn(model: AiModel): AgenticS
       maxTokens,
       tools,
       toolChoice,
+      abortSignal,
       providerName: 'Azure OpenAI',
       createOptions: {
         path: `/openai/responses`,

--- a/packages/ai-core/src/chat/providers/azure.ts
+++ b/packages/ai-core/src/chat/providers/azure.ts
@@ -44,7 +44,7 @@ function createAzureClient(model: AiModel): {
 export function constructAzureResponsesStreamFn(model: AiModel): TextStreamFn {
   const { client, deployment } = createAzureClient(model);
 
-  return async function* getAzureTextStream({ messages, maxTokens }, onComplete) {
+  return async function* getAzureTextStream({ messages, maxTokens, abortSignal }, onComplete) {
     const response = await client.responses.create(
       {
         model: deployment,
@@ -55,6 +55,7 @@ export function constructAzureResponsesStreamFn(model: AiModel): TextStreamFn {
       },
       {
         path: `/openai/responses`,
+        ...(abortSignal ? { signal: abortSignal } : {}),
       },
     );
 
@@ -122,7 +123,7 @@ export function constructAzureResponsesAgenticStreamFn(model: AiModel): AgenticS
 export function constructAzureResponsesGenerationFn(model: AiModel): TextGenerationFn {
   const { client, deployment } = createAzureClient(model);
 
-  return async function getAzureTextGeneration({ messages, maxTokens }) {
+  return async function getAzureTextGeneration({ messages, maxTokens, abortSignal }) {
     const response = await client.responses.create(
       {
         model: deployment,
@@ -133,6 +134,7 @@ export function constructAzureResponsesGenerationFn(model: AiModel): TextGenerat
       },
       {
         path: `/openai/responses`,
+        ...(abortSignal ? { signal: abortSignal } : {}),
       },
     );
 

--- a/packages/ai-core/src/chat/providers/bifrost.test.ts
+++ b/packages/ai-core/src/chat/providers/bifrost.test.ts
@@ -114,6 +114,7 @@ describe('Bifrost chat provider', () => {
         max_output_tokens: 128,
         reasoning: { effort: 'low' },
       }),
+      expect.anything(),
     );
     expect(responsesCreateMock.mock.calls[0]?.[0]).not.toHaveProperty('temperature');
     expect(result).toEqual({
@@ -133,7 +134,10 @@ describe('Bifrost chat provider', () => {
 
     await generateText({ messages: [{ role: 'user', content: 'Hello' }], model: model.name });
 
-    expect(responsesCreateMock).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-5' }));
+    expect(responsesCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'gpt-5' }),
+      expect.anything(),
+    );
   });
 
   it('strips the anthropic prefix from logical model names', async () => {
@@ -152,6 +156,7 @@ describe('Bifrost chat provider', () => {
 
     expect(responsesCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({ model: 'claude-3-5-sonnet-v2@20241022' }),
+      expect.anything(),
     );
   });
 
@@ -182,7 +187,10 @@ describe('Bifrost chat provider', () => {
       }
 
       expect(chunks).toEqual(['Hello', ' world']);
-      expect(responsesCreateMock).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-5' }));
+      expect(responsesCreateMock).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gpt-5' }),
+        expect.anything(),
+      );
       expect(onComplete).toHaveBeenCalledWith({
         promptTokens: 4,
         completionTokens: 5,
@@ -217,6 +225,7 @@ describe('Bifrost chat provider', () => {
 
     expect(responsesCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({ fallbacks: ['fallback'] }),
+      expect.anything(),
     );
     expect(result.modelId).toBe('model-fallback');
   });

--- a/packages/ai-core/src/chat/providers/bifrost.ts
+++ b/packages/ai-core/src/chat/providers/bifrost.ts
@@ -77,15 +77,21 @@ async function getUsedModelId(
 export function constructBifrostTextStreamFn(model: AiModel): TextStreamFn {
   const { client, modelName } = createBifrostClient(model);
 
-  return async function* getBifrostTextStream({ messages, maxTokens, fallbackModels }, onComplete) {
-    const response = await client.responses.create({
-      model: modelName,
-      input: toOpenAIResponsesInput(messages),
-      stream: true,
-      max_output_tokens: maxTokens,
-      ...model.additionalParameters,
-      ...(fallbackModels?.length ? { fallbacks: fallbackModels.map(getBifrostModelName) } : {}),
-    });
+  return async function* getBifrostTextStream(
+    { messages, maxTokens, fallbackModels, abortSignal },
+    onComplete,
+  ) {
+    const response = await client.responses.create(
+      {
+        model: modelName,
+        input: toOpenAIResponsesInput(messages),
+        stream: true,
+        max_output_tokens: maxTokens,
+        ...model.additionalParameters,
+        ...(fallbackModels?.length ? { fallbacks: fallbackModels.map(getBifrostModelName) } : {}),
+      },
+      { signal: abortSignal },
+    );
 
     let usage: TokenUsage | undefined;
     let modelId: string | undefined;
@@ -159,15 +165,23 @@ export function constructBifrostAgenticStreamFn(model: AiModel): AgenticStreamFn
 export function constructBifrostTextGenerationFn(model: AiModel): TextGenerationFn {
   const { client, modelName } = createBifrostClient(model);
 
-  return async function getBifrostTextGeneration({ messages, maxTokens, fallbackModels }) {
-    const response = await client.responses.create({
-      model: modelName,
-      input: toOpenAIResponsesInput(messages),
-      stream: false,
-      max_output_tokens: maxTokens,
-      ...model.additionalParameters,
-      ...(fallbackModels?.length ? { fallbacks: fallbackModels.map(getBifrostModelName) } : {}),
-    });
+  return async function getBifrostTextGeneration({
+    messages,
+    maxTokens,
+    fallbackModels,
+    abortSignal,
+  }) {
+    const response = await client.responses.create(
+      {
+        model: modelName,
+        input: toOpenAIResponsesInput(messages),
+        stream: false,
+        max_output_tokens: maxTokens,
+        ...model.additionalParameters,
+        ...(fallbackModels?.length ? { fallbacks: fallbackModels.map(getBifrostModelName) } : {}),
+      },
+      { signal: abortSignal },
+    );
 
     const textOutput = response.output.find((item) => item.type === 'message');
     const text =

--- a/packages/ai-core/src/chat/providers/bifrost.ts
+++ b/packages/ai-core/src/chat/providers/bifrost.ts
@@ -135,6 +135,7 @@ export function constructBifrostAgenticStreamFn(model: AiModel): AgenticStreamFn
     maxTokens,
     tools,
     toolChoice,
+    abortSignal,
     fallbackModels,
   }) {
     yield* streamOpenAICompatibleAgenticResponse({
@@ -144,6 +145,7 @@ export function constructBifrostAgenticStreamFn(model: AiModel): AgenticStreamFn
       maxTokens,
       tools,
       toolChoice,
+      abortSignal,
       providerName: 'Bifrost',
       additionalParameters: {
         ...(model.additionalParameters as Record<string, unknown>),

--- a/packages/ai-core/src/chat/providers/google-anthropic.test.ts
+++ b/packages/ai-core/src/chat/providers/google-anthropic.test.ts
@@ -133,13 +133,16 @@ describe('constructGoogleAnthropicTextGenerationFn', () => {
       model: 'anthropic/claude-3-5-sonnet-v2@20241022',
     });
 
-    expect(createMock).toHaveBeenCalledWith({
-      max_tokens: 2000,
-      messages: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
-      model: 'claude-3-5-sonnet-v2@20241022',
-      stream: false,
-      system: 'You are helpful',
-    });
+    expect(createMock).toHaveBeenCalledWith(
+      {
+        max_tokens: 2000,
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+        model: 'claude-3-5-sonnet-v2@20241022',
+        stream: false,
+        system: 'You are helpful',
+      },
+      expect.anything(),
+    );
   });
 
   it('should use default maxTokens of 4096 when not specified', async () => {
@@ -159,6 +162,7 @@ describe('constructGoogleAnthropicTextGenerationFn', () => {
       expect.objectContaining({
         max_tokens: 4096,
       }),
+      expect.anything(),
     );
   });
 
@@ -179,6 +183,7 @@ describe('constructGoogleAnthropicTextGenerationFn', () => {
       expect.objectContaining({
         model: 'claude-sonnet',
       }),
+      expect.anything(),
     );
   });
 
@@ -207,6 +212,7 @@ describe('constructGoogleAnthropicTextGenerationFn', () => {
         ],
         system: 'System prompt',
       }),
+      expect.anything(),
     );
   });
 
@@ -292,6 +298,7 @@ describe('constructGoogleAnthropicTextGenerationFn', () => {
           },
         ],
       }),
+      expect.anything(),
     );
   });
 
@@ -328,6 +335,7 @@ describe('constructGoogleAnthropicTextGenerationFn', () => {
           },
         ],
       }),
+      expect.anything(),
     );
   });
 
@@ -374,6 +382,7 @@ describe('constructGoogleAnthropicTextGenerationFn', () => {
           },
         ],
       }),
+      expect.anything(),
     );
   });
 

--- a/packages/ai-core/src/chat/providers/google-anthropic.test.ts
+++ b/packages/ai-core/src/chat/providers/google-anthropic.test.ts
@@ -652,6 +652,7 @@ describe('constructGoogleAnthropicAgenticStreamFn', () => {
           }),
         ],
       }),
+      expect.anything(),
     );
 
     expect(events).toEqual([
@@ -735,6 +736,7 @@ describe('constructGoogleAnthropicAgenticStreamFn', () => {
           },
         ],
       }),
+      expect.anything(),
     );
 
     expect(events).toEqual([{ type: 'text', delta: 'It is sunny' }]);
@@ -807,6 +809,7 @@ describe('constructGoogleAnthropicAgenticStreamFn', () => {
           },
         ]),
       }),
+      expect.anything(),
     );
   });
 
@@ -867,6 +870,7 @@ describe('constructGoogleAnthropicAgenticStreamFn', () => {
           },
         ]),
       }),
+      expect.anything(),
     );
   });
 

--- a/packages/ai-core/src/chat/providers/google-anthropic.ts
+++ b/packages/ai-core/src/chat/providers/google-anthropic.ts
@@ -140,7 +140,7 @@ export function constructGoogleAnthropicAgenticStreamFn(model: AiModel): Agentic
     args: TextGenerationArgs,
   ): AsyncGenerator<StreamEvent> {
     try {
-      const { messages, maxTokens, model: modelName, tools, toolChoice } = args;
+      const { messages, maxTokens, model: modelName, tools, toolChoice, abortSignal } = args;
       const systemMessages = getSystemMessages(messages);
       const conversationMessages = groupToolResults(
         getNonSystemMessages(messages).map((msg) => mapMessageToAnthropicMessageParam(msg)),
@@ -156,7 +156,7 @@ export function constructGoogleAnthropicAgenticStreamFn(model: AiModel): Agentic
         tools: mapToolsToAnthropicTools(tools),
       };
 
-      const stream = client.messages.stream(messageParams);
+      const stream = client.messages.stream(messageParams, { signal: abortSignal });
 
       // Track whether text was streamed as deltas to avoid duplication from finalMessage
       let hasStreamedTextDeltas = false;

--- a/packages/ai-core/src/chat/providers/google-anthropic.ts
+++ b/packages/ai-core/src/chat/providers/google-anthropic.ts
@@ -40,6 +40,7 @@ export function constructGoogleAnthropicTextGenerationFn(model: AiModel): TextGe
     messages,
     maxTokens,
     model: modelName,
+    abortSignal,
   }: TextGenerationArgs): Promise<TextResponse> {
     // Separate system messages from conversation messages
     const systemMessages = getSystemMessages(messages);
@@ -58,7 +59,7 @@ export function constructGoogleAnthropicTextGenerationFn(model: AiModel): TextGe
       system: buildSystemPrompt(systemMessages),
     };
 
-    const response = await client.messages.create(messageParams);
+    const response = await client.messages.create(messageParams, { signal: abortSignal });
 
     const text = response.content
       .filter((block) => block.type === 'text')
@@ -86,7 +87,7 @@ export function constructGoogleAnthropicTextStreamFn(model: AiModel): TextStream
     onComplete?: (usage: TokenUsage) => void | Promise<void>,
   ): AsyncGenerator<string> {
     try {
-      const { messages, maxTokens, model: modelName } = args;
+      const { messages, maxTokens, model: modelName, abortSignal } = args;
 
       // Separate system messages from conversation messages
       const systemMessages = getSystemMessages(messages);
@@ -105,7 +106,7 @@ export function constructGoogleAnthropicTextStreamFn(model: AiModel): TextStream
         system: buildSystemPrompt(systemMessages),
       };
 
-      const stream = client.messages.stream(messageParams);
+      const stream = client.messages.stream(messageParams, { signal: abortSignal });
 
       let usage: TokenUsage | undefined = undefined;
 

--- a/packages/ai-core/src/chat/providers/google.ts
+++ b/packages/ai-core/src/chat/providers/google.ts
@@ -229,7 +229,7 @@ export function constructGoogleTextStreamFn(model: AiModel): TextStreamFn {
   const clientConfig = createGoogleClient(model);
 
   return async function* getGoogleTextStream(
-    { messages, model: modelName, maxTokens, temperature },
+    { messages, model: modelName, maxTokens, temperature, abortSignal },
     onComplete,
   ) {
     try {
@@ -239,6 +239,7 @@ export function constructGoogleTextStreamFn(model: AiModel): TextStreamFn {
           model: modelName,
           maxTokens,
           temperature,
+          abortSignal,
         }),
       );
 
@@ -289,6 +290,7 @@ export function constructGoogleTextGenerationFn(model: AiModel): TextGenerationF
     model: modelName,
     maxTokens,
     temperature,
+    abortSignal,
   }) {
     try {
       const response = await clientConfig.client.models.generateContent(
@@ -297,6 +299,7 @@ export function constructGoogleTextGenerationFn(model: AiModel): TextGenerationF
           model: modelName,
           maxTokens,
           temperature,
+          abortSignal,
         }),
       );
 

--- a/packages/ai-core/src/chat/providers/google.ts
+++ b/packages/ai-core/src/chat/providers/google.ts
@@ -72,6 +72,7 @@ function buildGoogleGenerateContentParameters({
   temperature,
   tools,
   toolChoice,
+  abortSignal,
 }: Parameters<TextGenerationFn>[0]): GenerateContentParameters {
   const contents = messages
     .filter((message) => message.role !== 'system')
@@ -86,6 +87,7 @@ function buildGoogleGenerateContentParameters({
     ...(systemInstruction.length > 0 ? { systemInstruction } : {}),
     ...(maxTokens !== undefined ? { maxOutputTokens: maxTokens } : {}),
     ...(temperature !== undefined ? { temperature } : {}),
+    ...(abortSignal !== undefined ? { abortSignal } : {}),
     ...buildGoogleToolConfig(tools, toolChoice),
   };
 
@@ -333,6 +335,7 @@ export function constructGoogleAgenticStreamFn(model: AiModel): AgenticStreamFn 
     temperature,
     tools,
     toolChoice,
+    abortSignal,
   }) {
     try {
       const stream = await clientConfig.client.models.generateContentStream(
@@ -343,6 +346,7 @@ export function constructGoogleAgenticStreamFn(model: AiModel): AgenticStreamFn 
           temperature,
           tools,
           toolChoice,
+          abortSignal,
         }),
       );
 

--- a/packages/ai-core/src/chat/providers/ionos.ts
+++ b/packages/ai-core/src/chat/providers/ionos.ts
@@ -117,17 +117,21 @@ export function constructIonosAgenticStreamFn(model: AiModel): AgenticStreamFn {
     temperature,
     tools,
     toolChoice,
+    abortSignal,
   }) {
-    const stream = await client.chat.completions.create({
-      model: modelName,
-      messages: toOpenAIMessages(messages),
-      stream: true,
-      stream_options: { include_usage: true },
-      max_tokens: maxTokens,
-      temperature,
-      tools: toOpenAIChatTools(tools),
-      tool_choice: toolChoice,
-    });
+    const stream = await client.chat.completions.create(
+      {
+        model: modelName,
+        messages: toOpenAIMessages(messages),
+        stream: true,
+        stream_options: { include_usage: true },
+        max_tokens: maxTokens,
+        temperature,
+        tools: toOpenAIChatTools(tools),
+        tool_choice: toolChoice,
+      },
+      { signal: abortSignal },
+    );
 
     type ToolCallAccumulator = {
       id: string;

--- a/packages/ai-core/src/chat/providers/ionos.ts
+++ b/packages/ai-core/src/chat/providers/ionos.ts
@@ -28,17 +28,20 @@ export function constructIonosTextStreamFn(model: AiModel): TextStreamFn {
   const client = createIonosClient(model);
 
   return async function* getIonosTextStream(
-    { messages, model: modelName, maxTokens, temperature },
+    { messages, model: modelName, maxTokens, temperature, abortSignal },
     onComplete,
   ) {
-    const stream = await client.chat.completions.create({
-      model: modelName,
-      messages: toOpenAIMessages(messages),
-      stream: true,
-      stream_options: { include_usage: true },
-      max_tokens: maxTokens,
-      temperature,
-    });
+    const stream = await client.chat.completions.create(
+      {
+        model: modelName,
+        messages: toOpenAIMessages(messages),
+        stream: true,
+        stream_options: { include_usage: true },
+        max_tokens: maxTokens,
+        temperature,
+      },
+      { signal: abortSignal },
+    );
 
     let content = '';
 
@@ -79,14 +82,18 @@ export function constructIonosTextGenerationFn(model: AiModel): TextGenerationFn
     model: modelName,
     maxTokens,
     temperature,
+    abortSignal,
   }) {
-    const response = await client.chat.completions.create({
-      model: modelName,
-      messages: toOpenAIMessages(messages),
-      stream: false,
-      max_tokens: maxTokens,
-      temperature,
-    });
+    const response = await client.chat.completions.create(
+      {
+        model: modelName,
+        messages: toOpenAIMessages(messages),
+        stream: false,
+        max_tokens: maxTokens,
+        temperature,
+      },
+      { signal: abortSignal },
+    );
 
     const text = response.choices[0]?.message?.content ?? '';
 

--- a/packages/ai-core/src/chat/providers/openai-compatible.ts
+++ b/packages/ai-core/src/chat/providers/openai-compatible.ts
@@ -11,6 +11,7 @@ type OpenAICompatibleAgenticStreamArgs = {
   temperature?: number;
   tools?: ToolDefinition[];
   toolChoice?: 'auto' | 'none' | 'required';
+  abortSignal?: AbortSignal;
   getUsage?: (result: { content: string; toolCalls: ToolCall[] }) => TokenUsage;
   providerName: string;
   createOptions?: Parameters<OpenAI['responses']['create']>[1];
@@ -33,6 +34,7 @@ export async function* streamOpenAICompatibleAgenticResponse({
   temperature,
   tools,
   toolChoice,
+  abortSignal,
   getUsage,
   providerName,
   createOptions,
@@ -50,7 +52,7 @@ export async function* streamOpenAICompatibleAgenticResponse({
       tool_choice: toolChoice,
       ...additionalParameters,
     },
-    createOptions,
+    { ...createOptions, signal: abortSignal },
   );
 
   let content = '';

--- a/packages/ai-core/src/chat/providers/openai-compatible.ts
+++ b/packages/ai-core/src/chat/providers/openai-compatible.ts
@@ -52,7 +52,7 @@ export async function* streamOpenAICompatibleAgenticResponse({
       tool_choice: toolChoice,
       ...additionalParameters,
     },
-    { ...createOptions, signal: abortSignal },
+    { ...createOptions, ...(abortSignal ? { signal: abortSignal } : {}) },
   );
 
   let content = '';

--- a/packages/ai-core/src/chat/providers/openai.ts
+++ b/packages/ai-core/src/chat/providers/openai.ts
@@ -113,6 +113,7 @@ export function constructOpenAIAgenticStreamFn(model: AiModel): AgenticStreamFn 
     temperature,
     tools,
     toolChoice,
+    abortSignal,
   }) {
     yield* streamOpenAICompatibleAgenticResponse({
       client,
@@ -122,6 +123,7 @@ export function constructOpenAIAgenticStreamFn(model: AiModel): AgenticStreamFn 
       temperature,
       tools,
       toolChoice,
+      abortSignal,
       providerName: 'OpenAI',
     });
   };

--- a/packages/ai-core/src/chat/providers/openai.ts
+++ b/packages/ai-core/src/chat/providers/openai.ts
@@ -28,17 +28,20 @@ export function constructOpenAITextStreamFn(model: AiModel): TextStreamFn {
   const client = createOpenAIClient(model);
 
   return async function* getOpenAITextStream(
-    { messages, model: modelName, maxTokens, temperature },
+    { messages, model: modelName, maxTokens, temperature, abortSignal },
     onComplete,
   ) {
-    const stream = await client.chat.completions.create({
-      model: modelName,
-      messages: toOpenAIMessages(messages),
-      stream: true,
-      stream_options: { include_usage: true },
-      max_tokens: maxTokens,
-      temperature,
-    });
+    const stream = await client.chat.completions.create(
+      {
+        model: modelName,
+        messages: toOpenAIMessages(messages),
+        stream: true,
+        stream_options: { include_usage: true },
+        max_tokens: maxTokens,
+        temperature,
+      },
+      { signal: abortSignal },
+    );
 
     let usage: TokenUsage | undefined;
 
@@ -76,14 +79,18 @@ export function constructOpenAITextGenerationFn(model: AiModel): TextGenerationF
     model: modelName,
     maxTokens,
     temperature,
+    abortSignal,
   }) {
-    const response = await client.chat.completions.create({
-      model: modelName,
-      messages: toOpenAIMessages(messages),
-      stream: false,
-      max_tokens: maxTokens,
-      temperature,
-    });
+    const response = await client.chat.completions.create(
+      {
+        model: modelName,
+        messages: toOpenAIMessages(messages),
+        stream: false,
+        max_tokens: maxTokens,
+        temperature,
+      },
+      { signal: abortSignal },
+    );
 
     const text = response.choices[0]?.message?.content ?? '';
     const usage = response.usage;

--- a/packages/ai-core/src/chat/types.ts
+++ b/packages/ai-core/src/chat/types.ts
@@ -65,6 +65,8 @@ export type GenerationOptions = {
   temperature?: number;
   tools?: ToolDefinition[];
   toolChoice?: 'auto' | 'none' | 'required';
+  /** Aborts the upstream provider request so a stalled stream cannot be retained indefinitely. */
+  abortSignal?: AbortSignal;
   /** Resolved server-side models used only by the Bifrost provider. */
   fallbackModels?: AiModel[];
 };


### PR DESCRIPTION
Part 2 of 3 investigating the production memory growth in TD-1548. Independent of #1323. Part 3 is stacked on top of this one.

Production pods were accumulating ~1.3 GB of `arrayBuffers` between deployments, traced to ~22,700 live `ReadableStream` objects. About 14,800 of those were locked — a reader had been acquired and never released. This addresses that group.

Nothing in `ai-core` accepted an `AbortSignal`, and there was no timeout on any provider call. If a provider stalled mid-stream, the reader waited forever and its buffers were never released. `runAgentLoop` is also fire-and-forget, so a client hitting stop or closing the tab did not stop the server-side work — the loop kept calling the LLM and running tools to completion.

`abortSignal` is added to `GenerationOptions` and threaded to every provider: `openai-compatible` (covering OpenAI, Azure and Bifrost) via request options, `ionos` via `chat.completions.create`, `google` via `GenerateContentConfig.abortSignal`, and `google-anthropic` via `client.messages.stream`. `runAgentLoop` accepts the signal and also checks it between iterations, so a cancelled generation does not start another round of tool calls.

An abort is treated as expected teardown rather than a failure: no `onError`, and no spurious `EmptyResponseError`. Partial text still reaches `onComplete`, so a user who hits stop keeps what was already generated.

`createTextStream` now returns a `signal` that fires when the consumer cancels. That is the only trigger in this PR; the idle and max-duration triggers come in part 3.

The `google-anthropic` test assertions were updated because the SDK call now takes a second request-options argument.