### PR TITLE
TD-1548: Bound stream queue length and generation duration

### DIFF
--- a/apps/chat-bot/src/utils/streaming.test.ts
+++ b/apps/chat-bot/src/utils/streaming.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ChatStreamEvent } from './streaming';
 import {
   createTextStream,
@@ -83,6 +83,91 @@ describe('createTextStream', () => {
       done();
       error(new Error('ignored'));
     }).not.toThrow();
+  });
+
+  it('abandons the stream once the consumer stops draining it', () => {
+    const { signal, update } = createTextStream();
+
+    // One more than the queued chunk limit, so the last update sees a full queue.
+    for (let i = 0; i <= 1000; i++) {
+      update(`chunk ${i}`);
+    }
+
+    expect(signal.aborted).toBe(true);
+    expect((signal.reason as Error).message).toBe('consumer stopped reading');
+  });
+
+  describe('with fake timers', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('aborts the signal once the maximum duration elapses', () => {
+      const { signal, update } = createTextStream({
+        maxDurationMs: 1_000,
+        idleTimeoutMs: 60_000,
+      });
+
+      update('still going');
+      vi.advanceTimersByTime(1_000);
+
+      expect(signal.aborted).toBe(true);
+      expect((signal.reason as Error).message).toBe('generation exceeded maximum duration');
+    });
+
+    it('aborts the signal when the producer goes idle, and resets on each update', () => {
+      const { signal, update } = createTextStream({
+        maxDurationMs: 60_000,
+        idleTimeoutMs: 1_000,
+      });
+
+      vi.advanceTimersByTime(900);
+      update('activity');
+      vi.advanceTimersByTime(900);
+
+      expect(signal.aborted).toBe(false);
+
+      vi.advanceTimersByTime(100);
+
+      expect(signal.aborted).toBe(true);
+      expect((signal.reason as Error).message).toBe('producer stopped emitting text');
+    });
+
+    it('does not abort after done(), even if a late update arrives', () => {
+      const { signal, update, done } = createTextStream({
+        maxDurationMs: 60_000,
+        idleTimeoutMs: 1_000,
+      });
+
+      update('all of it');
+      done();
+      update('late chunk');
+
+      vi.advanceTimersByTime(60_000);
+
+      expect(signal.aborted).toBe(false);
+    });
+
+    it('does not abort after error(), even if a late update arrives', () => {
+      const { stream, signal, update, error } = createTextStream({
+        maxDurationMs: 60_000,
+        idleTimeoutMs: 1_000,
+      });
+
+      error(new Error('provider failed'));
+      update('late chunk');
+
+      vi.advanceTimersByTime(60_000);
+
+      expect(signal.aborted).toBe(false);
+
+      // Keep the rejected stream from surfacing as an unhandled rejection.
+      void stream.cancel().catch(() => {});
+    });
   });
 });
 

--- a/apps/chat-bot/src/utils/streaming.ts
+++ b/apps/chat-bot/src/utils/streaming.ts
@@ -36,13 +36,31 @@ export function decodeChatStreamEvent(chunk: string): ChatStreamEvent | null {
 }
 
 /**
+ * Number of chunks that may sit unread in the stream before the consumer is treated as gone.
+ * A live client drains continuously, so a backlog this large means nobody is reading.
+ */
+const MAX_QUEUED_CHUNKS = 1000;
+
+/** Hard ceiling for a single generation, independent of whether the client is still listening. */
+const DEFAULT_MAX_DURATION_MS = 10 * 60 * 1000;
+
+/**
+ * Aborts a producer that has gone quiet, which would otherwise hold its upstream stream forever.
+ * Generous enough to cover a slow agent iteration that runs tools before emitting any text.
+ */
+const DEFAULT_IDLE_TIMEOUT_MS = 3 * 60 * 1000;
+
+/**
  * Creates a streamable text value for Server Actions.
  * Returns a controller to update/complete the stream and a ReadableStream to consume.
  *
- * `signal` aborts once the consumer disappears, so the producer can tear down its own
- * upstream work instead of generating into a stream nobody reads.
+ * `signal` aborts when the consumer disappears, the producer goes idle, or the maximum duration
+ * elapses, so the producer can tear down its own upstream work instead of leaking it.
  */
-export function createTextStream(): {
+export function createTextStream({
+  maxDurationMs = DEFAULT_MAX_DURATION_MS,
+  idleTimeoutMs = DEFAULT_IDLE_TIMEOUT_MS,
+}: { maxDurationMs?: number; idleTimeoutMs?: number } = {}): {
   stream: ReadableStream<string>;
   signal: AbortSignal;
   update: (text: string) => void;
@@ -50,25 +68,69 @@ export function createTextStream(): {
   error: (err: Error) => void;
 } {
   let controller: ReadableStreamDefaultController<string>;
-  let cancelledByConsumer = false;
+  let abandoned = false;
   const abortController = new AbortController();
 
-  const stream = new ReadableStream<string>({
-    start(c) {
-      controller = c;
+  const maxDurationTimer = setTimeout(
+    () => abandon('generation exceeded maximum duration'),
+    maxDurationMs,
+  );
+  let idleTimer: ReturnType<typeof setTimeout>;
+
+  function clearTimers() {
+    clearTimeout(maxDurationTimer);
+    clearTimeout(idleTimer);
+  }
+
+  function resetIdleTimer() {
+    clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => abandon('producer stopped emitting text'), idleTimeoutMs);
+  }
+
+  function abandon(reason: string) {
+    if (abandoned) return;
+    abandoned = true;
+    clearTimers();
+    abortController.abort(new Error(reason));
+    try {
+      controller.close();
+    } catch {
+      // Already closed or errored
+    }
+  }
+
+  const stream = new ReadableStream<string>(
+    {
+      start(c) {
+        controller = c;
+      },
+      cancel() {
+        // Consumer canceled the stream (e.g., user reloaded or closed the tab)
+        abandon('consumer cancelled the stream');
+      },
     },
-    cancel() {
-      // Consumer canceled the stream (e.g., user reloaded or closed the tab)
-      cancelledByConsumer = true;
-      abortController.abort(new Error('consumer cancelled the stream'));
-    },
-  });
+    new CountQueuingStrategy({ highWaterMark: MAX_QUEUED_CHUNKS }),
+  );
+
+  resetIdleTimer();
 
   return {
     stream,
     signal: abortController.signal,
     update: (text: string) => {
-      if (cancelledByConsumer) return;
+      if (abandoned) return;
+
+      if (controller.desiredSize !== null && controller.desiredSize <= 0) {
+        logError(
+          'createTextStream.update: consumer stopped reading, abandoning stream',
+          new Error(`Queued chunk limit of ${MAX_QUEUED_CHUNKS} exceeded`),
+        );
+        abandon('consumer stopped reading');
+        return;
+      }
+
+      resetIdleTimer();
+
       try {
         controller.enqueue(text);
       } catch (err) {
@@ -76,7 +138,8 @@ export function createTextStream(): {
       }
     },
     done: () => {
-      if (cancelledByConsumer) return;
+      clearTimers();
+      if (abandoned) return;
       try {
         controller.close();
       } catch (err) {
@@ -84,7 +147,8 @@ export function createTextStream(): {
       }
     },
     error: (err: Error) => {
-      if (cancelledByConsumer) return;
+      clearTimers();
+      if (abandoned) return;
       try {
         controller.error(err);
       } catch (caughtErr) {

--- a/apps/chat-bot/src/utils/streaming.ts
+++ b/apps/chat-bot/src/utils/streaming.ts
@@ -69,6 +69,7 @@ export function createTextStream({
 } {
   let controller: ReadableStreamDefaultController<string>;
   let abandoned = false;
+  let finished = false;
   const abortController = new AbortController();
 
   const maxDurationTimer = setTimeout(
@@ -88,7 +89,7 @@ export function createTextStream({
   }
 
   function abandon(reason: string) {
-    if (abandoned) return;
+    if (abandoned || finished) return;
     abandoned = true;
     clearTimers();
     abortController.abort(new Error(reason));
@@ -118,7 +119,7 @@ export function createTextStream({
     stream,
     signal: abortController.signal,
     update: (text: string) => {
-      if (abandoned) return;
+      if (abandoned || finished) return;
 
       if (controller.desiredSize !== null && controller.desiredSize <= 0) {
         logError(
@@ -139,6 +140,7 @@ export function createTextStream({
     },
     done: () => {
       clearTimers();
+      finished = true;
       if (abandoned) return;
       try {
         controller.close();
@@ -148,6 +150,7 @@ export function createTextStream({
     },
     error: (err: Error) => {
       clearTimers();
+      finished = true;
       if (abandoned) return;
       try {
         controller.error(err);


### PR DESCRIPTION
Part 3 of 3 investigating the production memory growth in TD-1548.

**Stacked on #1324** — it targets that branch, not `main`, so the diff here stays at one file. It adds abort triggers to the signal #1324 introduces, so on `main` alone there would be nothing to fire and no consumer for it. Please review #1324 first, then either merge it and retarget this to `main`, or merge the stack in order.

Two unbounded behaviours remained after #1324:

`createTextStream` built its `ReadableStream` with the default `CountQueuingStrategy` high water mark of 1, and `update()` called `enqueue()` unconditionally without ever checking `desiredSize`. A consumer that stopped draining caused the internal queue to grow without limit. The stream now has an explicit queuing strategy and `update()` checks `desiredSize` before enqueuing; a backlog past the limit means nobody is reading, so the stream is abandoned and the signal fires.

Nothing bounded a generation's lifetime. A hung provider could hold its stream indefinitely, and the consumer-cancel trigger from #1324 does not help when the client is already gone and there is no request-scoped signal left to fire. An idle timer and an absolute max-duration timer now fire the same signal independently of the client. With the max-duration timer in place, every generation is bounded — there is no longer any path where a stream lives forever.

The idle timeout is 3 minutes rather than something tighter: an agent iteration can legitimately run a web search and scrape before emitting any text, and a shorter window risked aborting healthy generations. The idle timer resets on every `update()`, which includes the `web_search_results` events, so tool progress counts as activity.

The abort wiring lives inside `createTextStream` rather than at the three call sites, which would otherwise each need identical timer and listener bookkeeping.