### PR TITLE
TD-1519: Publish calculator Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,6 +44,11 @@ jobs:
             image_ref: ghcr.io/fwu-de/ais-chat-admin
             sentry_project: ${{ vars.SENTRY_PROJECT_ADMIN }}
             server_actions_secret: NEXT_SERVER_ACTIONS_ENCRYPTION_KEY_ADMIN
+          - image_name: ais-chat-calculator
+            dockerfile: services/calculator/Dockerfile
+            image_ref: ghcr.io/fwu-de/ais-chat-calculator
+            sentry_project: ''
+            server_actions_secret: ''
 
     steps:
       - name: Checkout repository

--- a/services/calculator/package-lock.json
+++ b/services/calculator/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@types/node": "24.13.3",
         "eslint": "10.8.1",
-        "tsx": "4.23.12",
+        "tsx": "4.23.13",
         "typescript": "6.0.3",
         "vitest": "4.1.11"
       }
@@ -3226,9 +3226,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.23.12",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
-      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "version": "4.23.13",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.13.tgz",
+      "integrity": "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Add the calculator image to the existing Docker publish matrix.

- Publishes `ghcr.io/fwu-de/ais-chat-calculator` with `latest` and commit-SHA tags.
- Reuses the existing Buildx cache, provenance, and attestation flow.
- Synchronizes the calculator npm lockfile so the Docker `npm ci` stages are reproducible.

Verification: calculator Docker build from repository root, Compose validation, formatting, and diff checks passed.