### PR TITLE
TD-1548: Bill generations that end in an abort

### DIFF
--- a/apps/chat-bot/src/app/api/character/character-chat-service.ts
+++ b/apps/chat-bot/src/app/api/character/character-chat-service.ts
@@ -1,4 +1,9 @@
-import { TokenPointsExceededError, SharedChatExpiredError, runAgentLoop } from '@ais-chat/ai-core';
+import {
+  TokenPointsExceededError,
+  SharedChatExpiredError,
+  runAgentLoop,
+  type TokenUsage,
+} from '@ais-chat/ai-core';
 import { NotFoundError } from '@shared/error';
 import { createTextStream, encodeChatStreamEvent } from '@/utils/streaming';
 import { getUserAndContextByUserId } from '@/auth/utils';
@@ -195,6 +200,45 @@ export async function sendCharacterMessage({
     imageAttachmentType,
   );
 
+  const persistUsage = async ({
+    usage,
+    priceInCents,
+    modelUsages,
+  }: {
+    usage: TokenUsage;
+    priceInCents: number;
+    modelUsages: Array<{ modelId: string; usage: TokenUsage; priceInCents: number }>;
+  }) => {
+    if (modelUsages.length === 0) {
+      return;
+    }
+
+    // Agentic requests can invoke several models across iterations. Persist each usage
+    // entry separately so pricing and reporting stay associated with the serving model.
+    for (const modelUsage of modelUsages) {
+      await dbUpdateTokenUsageByCharacterChatId({
+        modelId: modelUsage.modelId ?? generationModelId,
+        completionTokens: modelUsage.usage.completionTokens,
+        promptTokens: modelUsage.usage.promptTokens,
+        characterId: character.id,
+        userId: teacherUserAndContext.id,
+        costsInCent: modelUsage.priceInCents,
+      });
+    }
+
+    await sendRabbitmqEvent(
+      constructNewMessageEvent({
+        user: teacherUserAndContext,
+        promptTokens: usage.promptTokens,
+        completionTokens: usage.completionTokens,
+        costsInCent: priceInCents,
+        provider: definedModel.provider,
+        anonymous: true,
+        character,
+      }),
+    );
+  };
+
   runAgentLoop({
     modelSelection,
     apiKeyId,
@@ -206,37 +250,14 @@ export async function sendCharacterMessage({
       update(delta);
     },
     onComplete: async ({ usage, priceInCents, modelUsages }) => {
-      const { promptTokens, completionTokens } = usage;
-
-      // Agentic requests can invoke several models across iterations. Persist each usage
-      // entry separately so pricing and reporting stay associated with the serving model.
-      for (const modelUsage of modelUsages) {
-        await dbUpdateTokenUsageByCharacterChatId({
-          modelId: modelUsage.modelId ?? generationModelId,
-          completionTokens: modelUsage.usage.completionTokens,
-          promptTokens: modelUsage.usage.promptTokens,
-          characterId: character.id,
-          userId: teacherUserAndContext.id,
-          costsInCent: modelUsage.priceInCents,
-        });
-      }
-
-      await sendRabbitmqEvent(
-        constructNewMessageEvent({
-          user: teacherUserAndContext,
-          promptTokens,
-          completionTokens,
-          costsInCent: priceInCents,
-          provider: definedModel.provider,
-          anonymous: true,
-          character,
-        }),
-      );
+      await persistUsage({ usage, priceInCents, modelUsages });
 
       done();
     },
-    onError: (error) => {
+    onError: async (error, billedUsage) => {
       logError('Error during character chat streaming:', error);
+      await persistUsage(billedUsage);
+
       streamError(error);
     },
   });

--- a/apps/chat-bot/src/app/api/character/character-chat-service.ts
+++ b/apps/chat-bot/src/app/api/character/character-chat-service.ts
@@ -93,7 +93,6 @@ export async function sendCharacterMessage({
     model: definedModel,
     federalStateId: teacherUserAndContext.federalState.id,
   });
-  const generationModelId = modelSelection.modelIds[0];
 
   // Check expiry
   if (sharedChatHasExpired(character)) {
@@ -217,7 +216,7 @@ export async function sendCharacterMessage({
     // entry separately so pricing and reporting stay associated with the serving model.
     for (const modelUsage of modelUsages) {
       await dbUpdateTokenUsageByCharacterChatId({
-        modelId: modelUsage.modelId ?? generationModelId,
+        modelId: modelUsage.modelId,
         completionTokens: modelUsage.usage.completionTokens,
         promptTokens: modelUsage.usage.promptTokens,
         characterId: character.id,

--- a/apps/chat-bot/src/app/api/character/character-chat-service.ts
+++ b/apps/chat-bot/src/app/api/character/character-chat-service.ts
@@ -255,9 +255,13 @@ export async function sendCharacterMessage({
     },
     onError: async (error, billedUsage) => {
       logError('Error during character chat streaming:', error);
-      await persistUsage(billedUsage);
-
-      streamError(error);
+      try {
+        await persistUsage(billedUsage);
+      } catch (persistenceError) {
+        logError('Error persisting failed character chat usage:', persistenceError);
+      } finally {
+        streamError(error);
+      }
     },
   });
 

--- a/apps/chat-bot/src/app/api/chat/chat-service.test.ts
+++ b/apps/chat-bot/src/app/api/chat/chat-service.test.ts
@@ -395,6 +395,44 @@ describe('sendChatMessage', () => {
     );
   });
 
+  it('persists usage that was already billed when the generation fails', async () => {
+    mocks.runAgentLoopMock.mockImplementationOnce(
+      ({ onError }: Parameters<typeof runAgentLoop>[0]) => {
+        void onError(new Error('provider exploded'), {
+          usage: { promptTokens: 11, completionTokens: 22, totalTokens: 33 },
+          priceInCents: 44,
+          modelUsages: [
+            {
+              modelId: mainModel.id,
+              usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 },
+              priceInCents: 4,
+            },
+          ],
+        });
+      },
+    );
+
+    const { sendChatMessage } = await import('./chat-service');
+    const result = await sendChatMessage({
+      conversationId: conversation.id,
+      messages,
+      modelId: mainModel.id,
+      user: createUser(),
+    });
+
+    await expect(collectStream(result.stream)).rejects.toThrow('provider exploded');
+
+    expect(mocks.dbInsertConversationUsageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelId: mainModel.id,
+        promptTokens: 1,
+        completionTokens: 2,
+        costsInCent: 4,
+      }),
+    );
+    expect(mocks.sendRabbitmqEventMock).toHaveBeenCalled();
+  });
+
   it('does not persist retrieve_entire_file tool calls or results', async () => {
     mocks.runAgentLoopMock.mockImplementationOnce(
       ({ onComplete }: Parameters<typeof runAgentLoop>[0]) => {

--- a/apps/chat-bot/src/app/api/chat/chat-service.ts
+++ b/apps/chat-bot/src/app/api/chat/chat-service.ts
@@ -490,6 +490,47 @@ export async function sendChatMessage({
   const assistantMessageId = crypto.randomUUID();
   const assistantMessageOrderNumber = userMessageOrderNumber + 1;
 
+  async function persistUsage({
+    usage,
+    priceInCents,
+    modelUsages,
+  }: {
+    usage: TokenUsage;
+    priceInCents: number;
+    modelUsages: Array<{ modelId: string; usage: TokenUsage; priceInCents: number }>;
+  }) {
+    if (modelUsages.length === 0) {
+      return;
+    }
+
+    // Agentic requests can invoke several models across iterations. Persist each usage
+    // entry separately so pricing and reporting stay associated with the serving model.
+    await Promise.all(
+      modelUsages.map((modelUsage) =>
+        dbInsertConversationUsage({
+          conversationId: activeConversation.id,
+          userId: user.id,
+          modelId: modelUsage.modelId,
+          completionTokens: modelUsage.usage.completionTokens,
+          promptTokens: modelUsage.usage.promptTokens,
+          costsInCent: modelUsage.priceInCents,
+        }),
+      ),
+    );
+
+    await sendRabbitmqEvent(
+      constructNewMessageEvent({
+        user,
+        promptTokens: usage.promptTokens,
+        completionTokens: usage.completionTokens,
+        costsInCent: priceInCents,
+        provider: definedModel.provider,
+        anonymous: false,
+        conversation: activeConversation,
+      }),
+    );
+  }
+
   async function persistAssistantMessage({
     fullText,
     usage,
@@ -544,34 +585,7 @@ export async function sendChatMessage({
       });
     }
 
-    const { promptTokens, completionTokens } = usage;
-
-    // Agentic requests can invoke several models across iterations. Persist each usage
-    // entry separately so pricing and reporting stay associated with the serving model.
-    await Promise.all(
-      modelUsages.map((modelUsage) =>
-        dbInsertConversationUsage({
-          conversationId: activeConversation.id,
-          userId: user.id,
-          modelId: modelUsage.modelId,
-          completionTokens: modelUsage.usage.completionTokens,
-          promptTokens: modelUsage.usage.promptTokens,
-          costsInCent: modelUsage.priceInCents,
-        }),
-      ),
-    );
-
-    await sendRabbitmqEvent(
-      constructNewMessageEvent({
-        user,
-        promptTokens,
-        completionTokens,
-        costsInCent: priceInCents,
-        provider: definedModel.provider,
-        anonymous: false,
-        conversation: activeConversation,
-      }),
-    );
+    await persistUsage({ usage, priceInCents, modelUsages });
   }
 
   async function persistEmptyAssistantMessage() {
@@ -611,8 +625,9 @@ export async function sendChatMessage({
         streamError(error instanceof Error ? error : new Error('Unknown error'));
       }
     },
-    onError: async (error: Error) => {
+    onError: async (error: Error, billedUsage) => {
       await persistEmptyAssistantMessage();
+      await persistUsage(billedUsage);
 
       streamError(error);
     },

--- a/apps/chat-bot/src/app/api/chat/chat-service.ts
+++ b/apps/chat-bot/src/app/api/chat/chat-service.ts
@@ -626,10 +626,14 @@ export async function sendChatMessage({
       }
     },
     onError: async (error: Error, billedUsage) => {
-      await persistEmptyAssistantMessage();
-      await persistUsage(billedUsage);
-
-      streamError(error);
+      try {
+        await persistEmptyAssistantMessage();
+        await persistUsage(billedUsage);
+      } catch (persistenceError) {
+        logError('Error persisting failed agent loop usage:', persistenceError);
+      } finally {
+        streamError(error);
+      }
     },
   });
 

--- a/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
+++ b/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
@@ -260,9 +260,13 @@ export async function sendLearningScenarioMessage({
     },
     onError: async (error, billedUsage) => {
       logError('Error during shared chat streaming:', error);
-      await persistUsage(billedUsage);
-
-      streamError(error);
+      try {
+        await persistUsage(billedUsage);
+      } catch (persistenceError) {
+        logError('Error persisting failed shared chat usage:', persistenceError);
+      } finally {
+        streamError(error);
+      }
     },
   });
 

--- a/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
+++ b/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
@@ -1,4 +1,9 @@
-import { TokenPointsExceededError, SharedChatExpiredError, runAgentLoop } from '@ais-chat/ai-core';
+import {
+  TokenPointsExceededError,
+  SharedChatExpiredError,
+  runAgentLoop,
+  type TokenUsage,
+} from '@ais-chat/ai-core';
 import { NotFoundError } from '@shared/error';
 import { createTextStream, encodeChatStreamEvent } from '@/utils/streaming';
 import { getUserAndContextByUserId } from '@/auth/utils';
@@ -200,6 +205,45 @@ export async function sendLearningScenarioMessage({
     imageAttachmentType,
   );
 
+  const persistUsage = async ({
+    usage,
+    priceInCents,
+    modelUsages,
+  }: {
+    usage: TokenUsage;
+    priceInCents: number;
+    modelUsages: Array<{ modelId: string; usage: TokenUsage; priceInCents: number }>;
+  }) => {
+    if (modelUsages.length === 0) {
+      return;
+    }
+
+    // Agentic requests can invoke several models across iterations. Persist each usage
+    // entry separately so pricing and reporting stay associated with the serving model.
+    for (const modelUsage of modelUsages) {
+      await dbUpdateTokenUsageBySharedLearningScenarioId({
+        modelId: modelUsage.modelId ?? generationModelId,
+        completionTokens: modelUsage.usage.completionTokens,
+        promptTokens: modelUsage.usage.promptTokens,
+        learningScenarioId: learningScenario.id,
+        userId: teacherUserAndContext.id,
+        costsInCent: modelUsage.priceInCents,
+      });
+    }
+
+    await sendRabbitmqEvent(
+      constructNewMessageEvent({
+        user: teacherUserAndContext,
+        provider: definedModel.provider,
+        promptTokens: usage.promptTokens,
+        completionTokens: usage.completionTokens,
+        costsInCent: priceInCents,
+        anonymous: true,
+        sharedChat: learningScenario,
+      }),
+    );
+  };
+
   runAgentLoop({
     modelSelection,
     apiKeyId,
@@ -211,37 +255,14 @@ export async function sendLearningScenarioMessage({
       update(delta);
     },
     onComplete: async ({ usage, priceInCents, modelUsages }) => {
-      const { promptTokens, completionTokens } = usage;
-
-      // Agentic requests can invoke several models across iterations. Persist each usage
-      // entry separately so pricing and reporting stay associated with the serving model.
-      for (const modelUsage of modelUsages) {
-        await dbUpdateTokenUsageBySharedLearningScenarioId({
-          modelId: modelUsage.modelId ?? generationModelId,
-          completionTokens: modelUsage.usage.completionTokens,
-          promptTokens: modelUsage.usage.promptTokens,
-          learningScenarioId: learningScenario.id,
-          userId: teacherUserAndContext.id,
-          costsInCent: modelUsage.priceInCents,
-        });
-      }
-
-      await sendRabbitmqEvent(
-        constructNewMessageEvent({
-          user: teacherUserAndContext,
-          provider: definedModel.provider,
-          promptTokens,
-          completionTokens,
-          costsInCent: priceInCents,
-          anonymous: true,
-          sharedChat: learningScenario,
-        }),
-      );
+      await persistUsage({ usage, priceInCents, modelUsages });
 
       done();
     },
-    onError: (error) => {
+    onError: async (error, billedUsage) => {
       logError('Error during shared chat streaming:', error);
+      await persistUsage(billedUsage);
+
       streamError(error);
     },
   });

--- a/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
+++ b/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
@@ -98,7 +98,6 @@ export async function sendLearningScenarioMessage({
     model: definedModel,
     federalStateId: teacherUserAndContext.federalState.id,
   });
-  const generationModelId = modelSelection.modelIds[0];
 
   // Check expiry
   if (sharedChatHasExpired(learningScenario)) {
@@ -222,7 +221,7 @@ export async function sendLearningScenarioMessage({
     // entry separately so pricing and reporting stay associated with the serving model.
     for (const modelUsage of modelUsages) {
       await dbUpdateTokenUsageBySharedLearningScenarioId({
-        modelId: modelUsage.modelId ?? generationModelId,
+        modelId: modelUsage.modelId,
         completionTokens: modelUsage.usage.completionTokens,
         promptTokens: modelUsage.usage.promptTokens,
         learningScenarioId: learningScenario.id,

--- a/packages/ai-core/src/chat/agent-loop.test.ts
+++ b/packages/ai-core/src/chat/agent-loop.test.ts
@@ -125,7 +125,10 @@ describe('agent-loop', () => {
     });
 
     expect(onComplete).not.toHaveBeenCalled();
-    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ name: 'EmptyResponseError' }));
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'EmptyResponseError' }),
+      expect.objectContaining({ modelUsages: [] }),
+    );
   });
 
   it('does not insert separator on first iteration', async () => {
@@ -848,6 +851,117 @@ describe('agent-loop', () => {
 
       expect(onError).not.toHaveBeenCalled();
       expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it('reports billed usage when the abort leaves usage but no text', async () => {
+      const messages: Message[] = [{ role: 'user', content: 'Test query' }];
+      const onComplete = vi.fn();
+      const onError = vi.fn();
+      const abortController = new AbortController();
+
+      mockGenerateAgenticStreamWithBilling.mockImplementation(async function* (
+        _selection: unknown,
+        _messages: unknown,
+        _apiKeyId: unknown,
+        onUsage: (result: {
+          usage: TokenUsage;
+          priceInCents: number;
+          modelId: string;
+        }) => Promise<void>,
+      ) {
+        yield { type: 'finish', usage } satisfies StreamEvent;
+        await onUsage({ usage, priceInCents: 7, modelId: 'test-model' });
+        abortController.abort();
+      });
+
+      runAgentLoop({
+        modelSelection: { modelIds: ['test-model'], modelName: 'Test Model' },
+        apiKeyId: 'test-key',
+        messages,
+        agentName: 'Test Agent',
+        abortSignal: abortController.signal,
+        onTextChunk: vi.fn(),
+        onComplete,
+        onError,
+      });
+
+      await vi.waitFor(() => {
+        expect(onComplete).toHaveBeenCalled();
+      });
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(onComplete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fullText: '',
+          priceInCents: 7,
+          modelUsages: [{ modelId: 'test-model', usage, priceInCents: 7 }],
+        }),
+      );
+    });
+  });
+
+  describe('usage on failure', () => {
+    it('passes already billed usage to onError', async () => {
+      const messages: Message[] = [{ role: 'user', content: 'Test query' }];
+      const onComplete = vi.fn();
+      const onError = vi.fn();
+
+      let callCount = 0;
+      mockGenerateAgenticStreamWithBilling.mockImplementation(async function* (
+        _selection: unknown,
+        _messages: unknown,
+        _apiKeyId: unknown,
+        onUsage: (result: {
+          usage: TokenUsage;
+          priceInCents: number;
+          modelId: string;
+        }) => Promise<void>,
+      ) {
+        callCount++;
+        if (callCount === 1) {
+          yield { type: 'text', delta: 'First iteration.' } satisfies StreamEvent;
+          yield {
+            type: 'tool_call',
+            call: { id: 'call_1', name: 'test_tool', arguments: '{}' },
+          } satisfies StreamEvent;
+          yield { type: 'finish', usage } satisfies StreamEvent;
+          await onUsage({ usage, priceInCents: 3, modelId: 'test-model' });
+          return;
+        }
+
+        throw new Error('provider exploded');
+      });
+
+      const toolRegistry = {
+        test_tool: {
+          definition: { name: 'test_tool', description: 'Test', parameters: {} },
+          handler: async () => 'tool result',
+        },
+      };
+
+      runAgentLoop({
+        modelSelection: { modelIds: ['test-model'], modelName: 'Test Model' },
+        apiKeyId: 'test-key',
+        messages,
+        toolRegistry,
+        agentName: 'Test Agent',
+        onTextChunk: vi.fn(),
+        onComplete,
+        onError,
+      });
+
+      await vi.waitFor(() => {
+        expect(onError).toHaveBeenCalled();
+      });
+
+      expect(onComplete).not.toHaveBeenCalled();
+      expect(onError).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          priceInCents: 3,
+          modelUsages: [{ modelId: 'test-model', usage, priceInCents: 3 }],
+        }),
+      );
     });
   });
 });

--- a/packages/ai-core/src/chat/agent-loop.ts
+++ b/packages/ai-core/src/chat/agent-loop.ts
@@ -40,7 +40,18 @@ type RunAgentLoopParams = {
     modelUsages: Array<{ modelId: string; usage: TokenUsage; priceInCents: number }>;
     agentLoopMessages: AiCoreMessage[];
   }) => void;
-  onError: (error: Error) => void;
+  /**
+   * Receives whatever was billed before the failure, so a partially completed generation is
+   * still accounted for.
+   */
+  onError: (
+    error: Error,
+    billedUsage: {
+      usage: TokenUsage;
+      priceInCents: number;
+      modelUsages: Array<{ modelId: string; usage: TokenUsage; priceInCents: number }>;
+    },
+  ) => void;
 };
 
 export function runAgentLoop({
@@ -73,6 +84,13 @@ export function runAgentLoop({
         modelId: lastModelId,
         modelUsages,
         agentLoopMessages: loopMessages.slice(messages.length),
+      });
+
+    const fail = (error: Error) =>
+      onError(error, {
+        usage: totalUsage,
+        priceInCents: totalPriceInCents,
+        modelUsages,
       });
 
     try {
@@ -225,23 +243,28 @@ export function runAgentLoop({
       if (fullText.trim().length === 0) {
         // An abort before any output is a teardown, not an empty-response failure.
         if (!abortSignal?.aborted) {
-          onError(new EmptyResponseError({ modelId: lastModelId }));
+          fail(new EmptyResponseError({ modelId: lastModelId }));
+          return;
         }
-        return;
+
+        // Nothing was generated and nothing was billed, so there is nothing to report.
+        if (modelUsages.length === 0) {
+          return;
+        }
       }
 
       complete();
     } catch (error) {
       // An aborted generation is an expected teardown, not a failure to report, but whatever
-      // was already generated must still reach the caller so it can be persisted.
+      // was already generated must still reach the caller so it can be persisted and billed.
       if (abortSignal?.aborted) {
-        if (fullText.trim().length > 0) {
+        if (fullText.trim().length > 0 || modelUsages.length > 0) {
           complete();
         }
         return;
       }
       logError('Error during agent loop:', error);
-      onError(error instanceof Error ? error : new Error('Unknown error'));
+      fail(error instanceof Error ? error : new Error('Unknown error'));
     }
   })();
 }

--- a/packages/ai-core/src/chat/agent-loop.ts
+++ b/packages/ai-core/src/chat/agent-loop.ts
@@ -136,6 +136,9 @@ export function runAgentLoop({
                   totalTokens: totalUsage.totalTokens + usage.totalTokens,
                 };
                 totalPriceInCents += priceInCents;
+                if (usage.estimated) {
+                  agentSpan.setAttribute('gen_ai.usage.estimated', true);
+                }
               },
               tools.length > 0 && !isLastIteration
                 ? { tools, toolChoice: 'auto', abortSignal }

--- a/packages/ai-core/src/chat/agentic-stream.ts
+++ b/packages/ai-core/src/chat/agentic-stream.ts
@@ -1,3 +1,4 @@
+import { metrics } from '@opentelemetry/api';
 import { billTextGenerationUsageToApiKey, isApiKeyOverQuota } from '../api-keys/billing';
 import { generateAgenticStream } from './providers';
 import { hasAccessToModel } from '../api-keys/model-access';
@@ -5,6 +6,12 @@ import { AiGenerationError, InvalidModelError } from '../errors';
 import { getTextModelById } from '../models';
 import { getUsedModelId } from './model-selection';
 import type { TokenUsage, GenerationOptions, StreamEvent, Message, ModelSelection } from './types';
+
+const estimatedUsageCounter = metrics
+  .getMeter('ais-chat.billing', '0.0.1')
+  .createCounter('estimated_token_usage', {
+    description: 'Generations billed with locally estimated token usage instead of provider data',
+  });
 
 /**
  * Generates streaming agentic output using the specified model and messages, with access control and billing.
@@ -68,6 +75,14 @@ export async function* generateAgenticStreamWithBilling(
         const usedModelId = getUsedModelId(selection, event.modelId);
         const billingModel =
           [model, ...fallbackModels].find((candidate) => candidate.id === usedModelId) ?? model;
+
+        if (event.usage.estimated) {
+          estimatedUsageCounter.add(1, {
+            'gen_ai.request.model': billingModel.name,
+            'gen_ai.provider.name': billingModel.provider,
+          });
+        }
+
         const priceInCents = await billTextGenerationUsageToApiKey(
           apiKeyId,
           billingModel,

--- a/packages/ai-core/src/chat/agentic-stream.ts
+++ b/packages/ai-core/src/chat/agentic-stream.ts
@@ -76,18 +76,18 @@ export async function* generateAgenticStreamWithBilling(
         const billingModel =
           [model, ...fallbackModels].find((candidate) => candidate.id === usedModelId) ?? model;
 
+        const priceInCents = await billTextGenerationUsageToApiKey(
+          apiKeyId,
+          billingModel,
+          event.usage,
+        );
+
         if (event.usage.estimated) {
           estimatedUsageCounter.add(1, {
             'gen_ai.request.model': billingModel.name,
             'gen_ai.provider.name': billingModel.provider,
           });
         }
-
-        const priceInCents = await billTextGenerationUsageToApiKey(
-          apiKeyId,
-          billingModel,
-          event.usage,
-        );
         if (onComplete) {
           await onComplete({ usage: event.usage, priceInCents, modelId: usedModelId });
         }

--- a/packages/ai-core/src/chat/providers/google-anthropic.test.ts
+++ b/packages/ai-core/src/chat/providers/google-anthropic.test.ts
@@ -1042,4 +1042,73 @@ describe('constructGoogleAnthropicAgenticStreamFn', () => {
       },
     ]);
   });
+
+  it('should report the usage seen so far when the stream is aborted', async () => {
+    const model = createGoogleAnthropicModel();
+    const abortController = new AbortController();
+
+    streamMock.mockReturnValue({
+      [Symbol.asyncIterator]: async function* () {
+        yield { type: 'message_start', message: { usage: { input_tokens: 42, output_tokens: 0 } } };
+        yield { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Partial' } };
+        yield { type: 'message_delta', usage: { output_tokens: 7 } };
+        abortController.abort();
+        throw new Error('Request was aborted.');
+      },
+      finalMessage: finalMessageMock,
+    });
+
+    const generateAgenticStream = constructGoogleAnthropicAgenticStreamFn(model);
+    const events = [];
+
+    for await (const event of generateAgenticStream({
+      messages: [{ role: 'user', content: 'test' }],
+      model: 'anthropic/claude',
+      abortSignal: abortController.signal,
+    })) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([
+      { type: 'text', delta: 'Partial' },
+      {
+        type: 'finish',
+        usage: {
+          promptTokens: 42,
+          completionTokens: 7,
+          totalTokens: 49,
+        },
+      },
+    ]);
+  });
+
+  it('should estimate usage when the stream is aborted before any usage was reported', async () => {
+    const model = createGoogleAnthropicModel();
+    const abortController = new AbortController();
+
+    streamMock.mockReturnValue({
+      [Symbol.asyncIterator]: async function* () {
+        yield { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Partial' } };
+        abortController.abort();
+        throw new Error('Request was aborted.');
+      },
+      finalMessage: finalMessageMock,
+    });
+
+    const generateAgenticStream = constructGoogleAnthropicAgenticStreamFn(model);
+    const events = [];
+
+    for await (const event of generateAgenticStream({
+      messages: [{ role: 'user', content: 'test' }],
+      model: 'anthropic/claude',
+      abortSignal: abortController.signal,
+    })) {
+      events.push(event);
+    }
+
+    const finish = events[1];
+    expect(finish?.type).toBe('finish');
+    expect(finish?.type === 'finish' && finish.usage.estimated).toBe(true);
+    expect(finish?.type === 'finish' && finish.usage.promptTokens).toBeGreaterThan(0);
+  });
 });

--- a/packages/ai-core/src/chat/providers/google-anthropic.test.ts
+++ b/packages/ai-core/src/chat/providers/google-anthropic.test.ts
@@ -1053,7 +1053,7 @@ describe('constructGoogleAnthropicAgenticStreamFn', () => {
         yield { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Partial' } };
         yield { type: 'message_delta', usage: { output_tokens: 7 } };
         abortController.abort();
-        throw new Error('Request was aborted.');
+        throw Object.assign(new Error('Request was aborted.'), { name: 'AbortError' });
       },
       finalMessage: finalMessageMock,
     });
@@ -1090,7 +1090,7 @@ describe('constructGoogleAnthropicAgenticStreamFn', () => {
       [Symbol.asyncIterator]: async function* () {
         yield { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Partial' } };
         abortController.abort();
-        throw new Error('Request was aborted.');
+        throw Object.assign(new Error('Request was aborted.'), { name: 'AbortError' });
       },
       finalMessage: finalMessageMock,
     });

--- a/packages/ai-core/src/chat/providers/google-anthropic.ts
+++ b/packages/ai-core/src/chat/providers/google-anthropic.ts
@@ -30,7 +30,7 @@ import { AnthropicVertex, ClientOptions } from '@anthropic-ai/vertex-sdk';
 import { AiGenerationError, RateLimitExceededError } from '../../errors';
 import { ParsedMessage } from '@anthropic-ai/sdk';
 import { instrumentAnthropicAiClient } from '@sentry/core';
-import { estimateTokenUsage } from '../utils';
+import { estimateTokenUsage, isAbortError } from '../utils';
 
 /* used by apps/api when called with stream === false or as auxiliary model in chat-bot */
 export function constructGoogleAnthropicTextGenerationFn(model: AiModel): TextGenerationFn {
@@ -220,7 +220,7 @@ export function constructGoogleAnthropicAgenticStreamFn(model: AiModel): Agentic
         }
       }
     } catch (error) {
-      if (abortSignal?.aborted) {
+      if (isAbortError(error, abortSignal)) {
         // Partial tool calls are unusable, but the prompt was consumed upstream and still costs money.
         yield {
           type: 'finish',

--- a/packages/ai-core/src/chat/providers/google-anthropic.ts
+++ b/packages/ai-core/src/chat/providers/google-anthropic.ts
@@ -30,6 +30,7 @@ import { AnthropicVertex, ClientOptions } from '@anthropic-ai/vertex-sdk';
 import { AiGenerationError, RateLimitExceededError } from '../../errors';
 import { ParsedMessage } from '@anthropic-ai/sdk';
 import { instrumentAnthropicAiClient } from '@sentry/core';
+import { estimateTokenUsage } from '../utils';
 
 /* used by apps/api when called with stream === false or as auxiliary model in chat-bot */
 export function constructGoogleAnthropicTextGenerationFn(model: AiModel): TextGenerationFn {
@@ -140,8 +141,12 @@ export function constructGoogleAnthropicAgenticStreamFn(model: AiModel): Agentic
   return async function* generateAgenticStream(
     args: TextGenerationArgs,
   ): AsyncGenerator<StreamEvent> {
+    const { messages, maxTokens, model: modelName, tools, toolChoice, abortSignal } = args;
+    let streamedText = '';
+    // Usage reported while streaming, so an abort still has real numbers to bill.
+    let streamedUsage: TokenUsage | undefined;
+
     try {
-      const { messages, maxTokens, model: modelName, tools, toolChoice, abortSignal } = args;
       const systemMessages = getSystemMessages(messages);
       const conversationMessages = groupToolResults(
         getNonSystemMessages(messages).map((msg) => mapMessageToAnthropicMessageParam(msg)),
@@ -166,7 +171,19 @@ export function constructGoogleAnthropicAgenticStreamFn(model: AiModel): Agentic
       for await (const event of stream) {
         if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
           hasStreamedTextDeltas = true;
+          streamedText += event.delta.text;
           yield { type: 'text', delta: event.delta.text };
+        } else if (event.type === 'message_start') {
+          streamedUsage = buildTokenUsage(event.message.usage);
+        } else if (event.type === 'message_delta') {
+          // message_delta carries the cumulative output token count for the response so far.
+          const promptTokens = streamedUsage?.promptTokens ?? 0;
+          const completionTokens = event.usage.output_tokens;
+          streamedUsage = {
+            promptTokens,
+            completionTokens,
+            totalTokens: promptTokens + completionTokens,
+          };
         } else if (event.type === 'message_stop') {
           const message: ParsedMessage<null> = await stream.finalMessage();
           const { content, usage, stop_reason } = message;
@@ -203,6 +220,15 @@ export function constructGoogleAnthropicAgenticStreamFn(model: AiModel): Agentic
         }
       }
     } catch (error) {
+      if (abortSignal?.aborted) {
+        // Partial tool calls are unusable, but the prompt was consumed upstream and still costs money.
+        yield {
+          type: 'finish',
+          usage: streamedUsage ?? estimateTokenUsage({ messages, text: streamedText }),
+        };
+        return;
+      }
+
       handleError(error);
     }
   };

--- a/packages/ai-core/src/chat/providers/google.ts
+++ b/packages/ai-core/src/chat/providers/google.ts
@@ -27,7 +27,7 @@ import type {
 } from '../types';
 import { AiGenerationError, ResponsibleAIError } from '../../errors';
 import { createGoogleClient, formatGoogleError } from '../../google-client';
-import { estimateTokenUsage } from '../utils';
+import { estimateTokenUsage, isAbortError } from '../utils';
 import {
   constructGoogleAnthropicAgenticStreamFn,
   constructGoogleAnthropicTextGenerationFn,
@@ -400,7 +400,7 @@ export function constructGoogleAgenticStreamFn(model: AiModel): AgenticStreamFn 
         throw error;
       }
 
-      if (abortSignal?.aborted) {
+      if (isAbortError(error, abortSignal)) {
         // Partial tool calls are unusable, but the prompt was consumed upstream and still costs money.
         yield { type: 'finish', usage: usage ?? estimateTokenUsage({ messages, text }) };
         return;

--- a/packages/ai-core/src/chat/providers/google.ts
+++ b/packages/ai-core/src/chat/providers/google.ts
@@ -27,7 +27,7 @@ import type {
 } from '../types';
 import { AiGenerationError, ResponsibleAIError } from '../../errors';
 import { createGoogleClient, formatGoogleError } from '../../google-client';
-import { calculateCompletionUsage } from '../utils';
+import { estimateTokenUsage } from '../utils';
 import {
   constructGoogleAnthropicAgenticStreamFn,
   constructGoogleAnthropicTextGenerationFn,
@@ -210,16 +210,7 @@ function toTokenUsage({
     };
   }
 
-  const calculatedUsage = calculateCompletionUsage({
-    messages,
-    modelMessage: { role: 'assistant', content: text },
-  });
-
-  return {
-    promptTokens: calculatedUsage.prompt_tokens,
-    completionTokens: calculatedUsage.completion_tokens,
-    totalTokens: calculatedUsage.total_tokens,
-  };
+  return estimateTokenUsage({ messages, text });
 }
 
 export function constructGoogleTextStreamFn(model: AiModel): TextStreamFn {
@@ -340,6 +331,10 @@ export function constructGoogleAgenticStreamFn(model: AiModel): AgenticStreamFn 
     toolChoice,
     abortSignal,
   }) {
+    let text = '';
+    // Gemini reports cumulative usage on every chunk, so the last one survives an abort.
+    let usage: TokenUsage | undefined;
+
     try {
       const stream = await clientConfig.client.models.generateContentStream(
         buildGoogleGenerateContentParameters({
@@ -353,8 +348,6 @@ export function constructGoogleAgenticStreamFn(model: AiModel): AgenticStreamFn 
         }),
       );
 
-      let text = '';
-      let usage: TokenUsage | undefined;
       let functionCalls: NonNullable<GenerateContentResponse['functionCalls']> | undefined;
 
       for await (const chunk of stream) {
@@ -405,6 +398,12 @@ export function constructGoogleAgenticStreamFn(model: AiModel): AgenticStreamFn 
     } catch (error) {
       if (error instanceof ResponsibleAIError || error instanceof AiGenerationError) {
         throw error;
+      }
+
+      if (abortSignal?.aborted) {
+        // Partial tool calls are unusable, but the prompt was consumed upstream and still costs money.
+        yield { type: 'finish', usage: usage ?? estimateTokenUsage({ messages, text }) };
+        return;
       }
 
       throw new AiGenerationError(formatGoogleError('Google Vertex AI Agentic stream', error));

--- a/packages/ai-core/src/chat/providers/ionos.ts
+++ b/packages/ai-core/src/chat/providers/ionos.ts
@@ -9,7 +9,7 @@ import type {
   TokenUsage,
 } from '../types';
 import { ProviderConfigurationError } from '../../errors';
-import { estimateTokenUsage, toOpenAIChatTools, toOpenAIMessages } from '../utils';
+import { estimateTokenUsage, isAbortError, toOpenAIChatTools, toOpenAIMessages } from '../utils';
 
 function createIonosClient(model: AiModel): OpenAI {
   if (model.setting.provider !== 'ionos') {
@@ -183,7 +183,7 @@ export function constructIonosAgenticStreamFn(model: AiModel): AgenticStreamFn {
         }
       }
     } catch (error) {
-      if (!abortSignal?.aborted) {
+      if (!isAbortError(error, abortSignal)) {
         throw error;
       }
 

--- a/packages/ai-core/src/chat/providers/ionos.ts
+++ b/packages/ai-core/src/chat/providers/ionos.ts
@@ -9,12 +9,7 @@ import type {
   TokenUsage,
 } from '../types';
 import { ProviderConfigurationError } from '../../errors';
-import {
-  calculateCompletionUsage,
-  estimateTokenUsage,
-  toOpenAIChatTools,
-  toOpenAIMessages,
-} from '../utils';
+import { estimateTokenUsage, toOpenAIChatTools, toOpenAIMessages } from '../utils';
 
 function createIonosClient(model: AiModel): OpenAI {
   if (model.setting.provider !== 'ionos') {
@@ -59,19 +54,12 @@ export function constructIonosTextStreamFn(model: AiModel): TextStreamFn {
       }
     }
 
-    // Calculate the token usage manually as IONOS does not return it
     // TODO: Add token count for image inputs
     // See: https://platform.openai.com/docs/guides/images-vision?api-mode=responses&format=file
-    const calculatedUsage = calculateCompletionUsage({
+    const usage = estimateTokenUsage({
       messages,
-      modelMessage: { role: 'assistant', content },
+      text: content,
     });
-
-    const usage: TokenUsage = {
-      completionTokens: calculatedUsage.completion_tokens,
-      promptTokens: calculatedUsage.prompt_tokens,
-      totalTokens: calculatedUsage.total_tokens,
-    };
 
     if (onComplete) {
       await onComplete(usage);
@@ -102,19 +90,14 @@ export function constructIonosTextGenerationFn(model: AiModel): TextGenerationFn
 
     const text = response.choices[0]?.message?.content ?? '';
 
-    // Calculate the token usage manually as IONOS does not return it reliably
-    const calculatedUsage = calculateCompletionUsage({
+    const usage = estimateTokenUsage({
       messages,
-      modelMessage: { role: 'assistant', content: text },
+      text,
     });
 
     return {
       text,
-      usage: {
-        completionTokens: calculatedUsage.completion_tokens,
-        promptTokens: calculatedUsage.prompt_tokens,
-        totalTokens: calculatedUsage.total_tokens,
-      },
+      usage,
     };
   };
 }
@@ -226,16 +209,10 @@ export function constructIonosAgenticStreamFn(model: AiModel): AgenticStreamFn {
         ),
       ].join('');
 
-      const calculatedUsage = calculateCompletionUsage({
+      usage = estimateTokenUsage({
         messages,
-        modelMessage: { role: 'assistant', content: completionContent },
+        text: completionContent,
       });
-
-      usage = {
-        completionTokens: calculatedUsage.completion_tokens,
-        promptTokens: calculatedUsage.prompt_tokens,
-        totalTokens: calculatedUsage.total_tokens,
-      };
     }
 
     for (const toolCall of resolvedToolCalls) {

--- a/packages/ai-core/src/chat/providers/ionos.ts
+++ b/packages/ai-core/src/chat/providers/ionos.ts
@@ -9,7 +9,12 @@ import type {
   TokenUsage,
 } from '../types';
 import { ProviderConfigurationError } from '../../errors';
-import { calculateCompletionUsage, toOpenAIChatTools, toOpenAIMessages } from '../utils';
+import {
+  calculateCompletionUsage,
+  estimateTokenUsage,
+  toOpenAIChatTools,
+  toOpenAIMessages,
+} from '../utils';
 
 function createIonosClient(model: AiModel): OpenAI {
   if (model.setting.provider !== 'ionos') {
@@ -150,48 +155,58 @@ export function constructIonosAgenticStreamFn(model: AiModel): AgenticStreamFn {
     let usage: TokenUsage | undefined;
     const toolCalls = new Map<number, ToolCallAccumulator>();
 
-    for await (const chunk of stream) {
-      const delta = chunk.choices[0]?.delta;
-      const chunkContent = delta?.content;
+    try {
+      for await (const chunk of stream) {
+        const delta = chunk.choices[0]?.delta;
+        const chunkContent = delta?.content;
 
-      if (chunkContent) {
-        content += chunkContent;
-        yield { type: 'text', delta: chunkContent };
-      }
-
-      if (chunk.usage) {
-        usage = {
-          completionTokens: chunk.usage.completion_tokens,
-          promptTokens: chunk.usage.prompt_tokens,
-          totalTokens: chunk.usage.total_tokens,
-        };
-      }
-
-      if (!delta?.tool_calls) {
-        continue;
-      }
-
-      for (const toolCallDelta of delta.tool_calls) {
-        const existingToolCall = toolCalls.get(toolCallDelta.index) ?? {
-          id: '',
-          name: '',
-          arguments: '',
-        };
-
-        if (toolCallDelta.id) {
-          existingToolCall.id = toolCallDelta.id;
+        if (chunkContent) {
+          content += chunkContent;
+          yield { type: 'text', delta: chunkContent };
         }
 
-        if (toolCallDelta.function?.name) {
-          existingToolCall.name = toolCallDelta.function.name;
+        if (chunk.usage) {
+          usage = {
+            completionTokens: chunk.usage.completion_tokens,
+            promptTokens: chunk.usage.prompt_tokens,
+            totalTokens: chunk.usage.total_tokens,
+          };
         }
 
-        if (toolCallDelta.function?.arguments) {
-          existingToolCall.arguments += toolCallDelta.function.arguments;
+        if (!delta?.tool_calls) {
+          continue;
         }
 
-        toolCalls.set(toolCallDelta.index, existingToolCall);
+        for (const toolCallDelta of delta.tool_calls) {
+          const existingToolCall = toolCalls.get(toolCallDelta.index) ?? {
+            id: '',
+            name: '',
+            arguments: '',
+          };
+
+          if (toolCallDelta.id) {
+            existingToolCall.id = toolCallDelta.id;
+          }
+
+          if (toolCallDelta.function?.name) {
+            existingToolCall.name = toolCallDelta.function.name;
+          }
+
+          if (toolCallDelta.function?.arguments) {
+            existingToolCall.arguments += toolCallDelta.function.arguments;
+          }
+
+          toolCalls.set(toolCallDelta.index, existingToolCall);
+        }
       }
+    } catch (error) {
+      if (!abortSignal?.aborted) {
+        throw error;
+      }
+
+      // Partial tool calls are unusable, but the prompt was consumed upstream and still costs money.
+      yield { type: 'finish', usage: usage ?? estimateTokenUsage({ messages, text: content }) };
+      return;
     }
 
     const resolvedToolCalls: ToolCall[] = [...toolCalls.entries()]

--- a/packages/ai-core/src/chat/providers/openai-compatible.test.ts
+++ b/packages/ai-core/src/chat/providers/openai-compatible.test.ts
@@ -72,7 +72,7 @@ describe('streamOpenAICompatibleAgenticResponse', () => {
           [Symbol.asyncIterator]: async function* () {
             yield { type: 'response.output_text.delta', delta: 'Partial answer' };
             abortController.abort();
-            throw new Error('Request was aborted.');
+            throw Object.assign(new Error('Request was aborted.'), { name: 'AbortError' });
           },
         }),
       },
@@ -126,5 +126,30 @@ describe('streamOpenAICompatibleAgenticResponse', () => {
     };
 
     await expect(drain()).rejects.toThrow('upstream exploded');
+  });
+
+  it('rethrows unrelated stream errors when the signal was aborted', async () => {
+    const abortController = new AbortController();
+    const client = {
+      responses: {
+        create: vi.fn().mockResolvedValue({
+          [Symbol.asyncIterator]: async function* () {
+            yield* [];
+            abortController.abort();
+            throw new Error('upstream exploded');
+          },
+        }),
+      },
+    } as unknown as OpenAI;
+
+    const generator = streamOpenAICompatibleAgenticResponse({
+      client,
+      messages: [{ role: 'user', content: 'Hi' }],
+      modelName: 'test-model',
+      providerName: 'Test',
+      abortSignal: abortController.signal,
+    });
+
+    await expect(generator.next()).rejects.toThrow('upstream exploded');
   });
 });

--- a/packages/ai-core/src/chat/providers/openai-compatible.test.ts
+++ b/packages/ai-core/src/chat/providers/openai-compatible.test.ts
@@ -63,4 +63,68 @@ describe('streamOpenAICompatibleAgenticResponse', () => {
 
     await expect(drain()).rejects.toThrow(AiGenerationError);
   });
+
+  it('bills estimated usage when the stream is aborted mid-generation', async () => {
+    const abortController = new AbortController();
+    const client = {
+      responses: {
+        create: vi.fn().mockResolvedValue({
+          [Symbol.asyncIterator]: async function* () {
+            yield { type: 'response.output_text.delta', delta: 'Partial answer' };
+            abortController.abort();
+            throw new Error('Request was aborted.');
+          },
+        }),
+      },
+    } as unknown as OpenAI;
+
+    const events = [];
+    for await (const event of streamOpenAICompatibleAgenticResponse({
+      client,
+      messages: [{ role: 'user', content: 'Hi' }],
+      modelName: 'test-model',
+      providerName: 'Test',
+      abortSignal: abortController.signal,
+    })) {
+      events.push(event);
+    }
+
+    expect(events[0]).toEqual({ type: 'text', delta: 'Partial answer' });
+
+    const finish = events[1];
+    expect(finish?.type).toBe('finish');
+    expect(finish?.type === 'finish' && finish.usage.estimated).toBe(true);
+    expect(finish?.type === 'finish' && finish.usage.completionTokens).toBeGreaterThan(0);
+    expect(finish?.type === 'finish' && finish.usage.promptTokens).toBeGreaterThan(0);
+  });
+
+  it('rethrows stream errors when nothing was aborted', async () => {
+    const client = {
+      responses: {
+        create: vi.fn().mockResolvedValue({
+          [Symbol.asyncIterator]: async function* () {
+            yield { type: 'response.output_text.delta', delta: 'Partial' };
+            throw new Error('upstream exploded');
+          },
+        }),
+      },
+    } as unknown as OpenAI;
+
+    const generator = streamOpenAICompatibleAgenticResponse({
+      client,
+      messages: [{ role: 'user', content: 'Hi' }],
+      modelName: 'test-model',
+      providerName: 'Test',
+      abortSignal: new AbortController().signal,
+    });
+
+    const drain = async () => {
+      let result = await generator.next();
+      while (!result.done) {
+        result = await generator.next();
+      }
+    };
+
+    await expect(drain()).rejects.toThrow('upstream exploded');
+  });
 });

--- a/packages/ai-core/src/chat/providers/openai-compatible.ts
+++ b/packages/ai-core/src/chat/providers/openai-compatible.ts
@@ -1,7 +1,7 @@
 import type OpenAI from 'openai';
 import type { Message, StreamEvent, TokenUsage, ToolCall, ToolDefinition } from '../types';
 import { AiGenerationError } from '../../errors';
-import { toOpenAIResponsesInput, toOpenAITools } from '../utils';
+import { estimateTokenUsage, toOpenAIResponsesInput, toOpenAITools } from '../utils';
 
 type OpenAICompatibleAgenticStreamArgs = {
   client: OpenAI;
@@ -60,59 +60,72 @@ export async function* streamOpenAICompatibleAgenticResponse({
   let modelId: string | undefined;
   const toolCalls = new Map<number, ToolCallAccumulator>();
 
-  for await (const chunk of stream) {
-    if (chunk.type === 'response.output_text.delta') {
-      content += chunk.delta;
-      yield { type: 'text', delta: chunk.delta };
-    } else if (chunk.type === 'response.function_call_arguments.delta') {
-      const existingToolCall = toolCalls.get(chunk.output_index) ?? {
-        id: '',
-        callId: '',
-        name: '',
-        arguments: '',
-      };
+  try {
+    for await (const chunk of stream) {
+      if (chunk.type === 'response.output_text.delta') {
+        content += chunk.delta;
+        yield { type: 'text', delta: chunk.delta };
+      } else if (chunk.type === 'response.function_call_arguments.delta') {
+        const existingToolCall = toolCalls.get(chunk.output_index) ?? {
+          id: '',
+          callId: '',
+          name: '',
+          arguments: '',
+        };
 
-      existingToolCall.arguments += chunk.delta;
-      toolCalls.set(chunk.output_index, existingToolCall);
-    } else if (chunk.type === 'response.function_call_arguments.done') {
-      const existingToolCall = toolCalls.get(chunk.output_index) ?? {
-        id: '',
-        callId: '',
-        name: '',
-        arguments: '',
-      };
+        existingToolCall.arguments += chunk.delta;
+        toolCalls.set(chunk.output_index, existingToolCall);
+      } else if (chunk.type === 'response.function_call_arguments.done') {
+        const existingToolCall = toolCalls.get(chunk.output_index) ?? {
+          id: '',
+          callId: '',
+          name: '',
+          arguments: '',
+        };
 
-      existingToolCall.name = chunk.name;
-      existingToolCall.arguments = chunk.arguments;
-      toolCalls.set(chunk.output_index, existingToolCall);
-    } else if (chunk.type === 'response.output_item.done' && chunk.item.type === 'function_call') {
-      const existingToolCall = toolCalls.get(chunk.output_index) ?? {
-        id: '',
-        callId: '',
-        name: '',
-        arguments: '',
-      };
+        existingToolCall.name = chunk.name;
+        existingToolCall.arguments = chunk.arguments;
+        toolCalls.set(chunk.output_index, existingToolCall);
+      } else if (
+        chunk.type === 'response.output_item.done' &&
+        chunk.item.type === 'function_call'
+      ) {
+        const existingToolCall = toolCalls.get(chunk.output_index) ?? {
+          id: '',
+          callId: '',
+          name: '',
+          arguments: '',
+        };
 
-      existingToolCall.id = chunk.item.id ?? chunk.item.call_id;
-      existingToolCall.callId = chunk.item.call_id;
-      existingToolCall.name = chunk.item.name;
-      existingToolCall.arguments = chunk.item.arguments;
-      toolCalls.set(chunk.output_index, existingToolCall);
-    } else if (
-      (chunk.type === 'response.completed' ||
-        chunk.type === 'response.incomplete' ||
-        chunk.type === 'response.failed') &&
-      chunk.response.usage
-    ) {
-      usage = {
-        completionTokens: chunk.response.usage.output_tokens,
-        promptTokens: chunk.response.usage.input_tokens,
-        totalTokens: chunk.response.usage.total_tokens,
-      };
-      modelId = await getModelId?.(
-        (chunk.response as typeof chunk.response & { extra_fields?: unknown }).extra_fields,
-      );
+        existingToolCall.id = chunk.item.id ?? chunk.item.call_id;
+        existingToolCall.callId = chunk.item.call_id;
+        existingToolCall.name = chunk.item.name;
+        existingToolCall.arguments = chunk.item.arguments;
+        toolCalls.set(chunk.output_index, existingToolCall);
+      } else if (
+        (chunk.type === 'response.completed' ||
+          chunk.type === 'response.incomplete' ||
+          chunk.type === 'response.failed') &&
+        chunk.response.usage
+      ) {
+        usage = {
+          completionTokens: chunk.response.usage.output_tokens,
+          promptTokens: chunk.response.usage.input_tokens,
+          totalTokens: chunk.response.usage.total_tokens,
+        };
+        modelId = await getModelId?.(
+          (chunk.response as typeof chunk.response & { extra_fields?: unknown }).extra_fields,
+        );
+      }
     }
+  } catch (error) {
+    if (!abortSignal?.aborted) {
+      throw error;
+    }
+
+    // Partial tool calls are unusable, but the prompt was consumed upstream and still costs money.
+    yield { type: 'finish', usage: usage ?? estimateTokenUsage({ messages, text: content }) };
+    return;
   }
 
   const resolvedToolCalls: ToolCall[] = [];

--- a/packages/ai-core/src/chat/providers/openai-compatible.ts
+++ b/packages/ai-core/src/chat/providers/openai-compatible.ts
@@ -1,7 +1,7 @@
 import type OpenAI from 'openai';
 import type { Message, StreamEvent, TokenUsage, ToolCall, ToolDefinition } from '../types';
 import { AiGenerationError } from '../../errors';
-import { estimateTokenUsage, toOpenAIResponsesInput, toOpenAITools } from '../utils';
+import { estimateTokenUsage, isAbortError, toOpenAIResponsesInput, toOpenAITools } from '../utils';
 
 type OpenAICompatibleAgenticStreamArgs = {
   client: OpenAI;
@@ -119,7 +119,7 @@ export async function* streamOpenAICompatibleAgenticResponse({
       }
     }
   } catch (error) {
-    if (!abortSignal?.aborted) {
+    if (!isAbortError(error, abortSignal)) {
       throw error;
     }
 

--- a/packages/ai-core/src/chat/types.ts
+++ b/packages/ai-core/src/chat/types.ts
@@ -82,6 +82,8 @@ export type TokenUsage = {
   completionTokens: number;
   promptTokens: number;
   totalTokens: number;
+  /** Set when the provider never reported usage and the numbers were derived locally. */
+  estimated?: boolean;
 };
 
 export type ModelSelection = {

--- a/packages/ai-core/src/chat/utils.ts
+++ b/packages/ai-core/src/chat/utils.ts
@@ -1,6 +1,6 @@
 import { getEncoding, type Tiktoken } from 'js-tiktoken';
 import type OpenAI from 'openai';
-import type { Message, ToolDefinition } from './types';
+import type { Message, TokenUsage, ToolDefinition } from './types';
 
 /**
  * Converts internal Message format to OpenAI ChatCompletionMessageParam format.
@@ -221,5 +221,29 @@ export function calculateCompletionUsage({
     prompt_tokens: promptTokens,
     completion_tokens: completionTokens,
     total_tokens: promptTokens + completionTokens,
+  };
+}
+
+/**
+ * Usage for a generation that ended before the provider reported real numbers, e.g. an abort.
+ * The prompt was already consumed upstream, so the cost is estimated rather than dropped.
+ */
+export function estimateTokenUsage({
+  messages,
+  text,
+}: {
+  messages: Message[];
+  text: string;
+}): TokenUsage {
+  const usage = calculateCompletionUsage({
+    messages,
+    modelMessage: { role: 'assistant', content: text },
+  });
+
+  return {
+    promptTokens: usage.prompt_tokens,
+    completionTokens: usage.completion_tokens,
+    totalTokens: usage.total_tokens,
+    estimated: true,
   };
 }

--- a/packages/ai-core/src/chat/utils.ts
+++ b/packages/ai-core/src/chat/utils.ts
@@ -247,3 +247,25 @@ export function estimateTokenUsage({
     estimated: true,
   };
 }
+
+/**
+ * Returns true only for provider errors caused by the supplied abort signal.
+ */
+export function isAbortError(error: unknown, signal?: AbortSignal): boolean {
+  if (!signal?.aborted) {
+    return false;
+  }
+
+  if (error === signal.reason) {
+    return true;
+  }
+
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const errorCode = 'code' in error ? error.code : undefined;
+  return (
+    error.name === 'AbortError' || error.name === 'APIUserAbortError' || errorCode === 'ABORT_ERR'
+  );
+}


### PR DESCRIPTION
Follow-up to the TD-1548 memory work (#1323, #1324, #1325). Billing was gated entirely on the provider's `finish` event, which every provider yields only after its stream loop completes. An abort makes that loop throw, so the event never arrived and nothing was recorded: no api-key quota via `billTextGenerationUsageToApiKey`, no `conversation_usage_tracking` rows, and a `new-message` analytics event carrying zeros. Before #1324 the stop button did not abort server-side work at all, so this was latent; now that consumer cancel, the queue backlog check, the idle timeout and the 10-minute ceiling all fire aborts automatically, closing a tab mid-generation means unmetered inference.

Providers now catch the abort and emit `finish` instead of throwing, so the single existing billing path keeps working untouched. Google reports cumulative `usageMetadata` on every chunk and Anthropic reports usage through `message_start` and `message_delta`, so both bill real provider numbers on abort — the Anthropic events were previously only read via `finalMessage()` at `message_stop`, which an abort never reaches. The OpenAI family and IONOS only report usage in their final chunk, so those fall back to a local tiktoken estimate, flagged with `estimated: true` on `TokenUsage` and counted by a new `estimated_token_usage` metric per model and provider. Note the estimator is biased low: it counts message text only, ignoring image attachments, tool definitions and provider-side overhead.

The agent loop also had two holes that dropped usage independently of the abort work. It returned early on empty text without calling `onComplete`, and `onError` received no usage at all, so a failure in a later agent iteration discarded what earlier iterations had already been billed for. `onError` now carries the accumulated usage, and the three chat services share a `persistUsage` helper called from both the success and failure paths.

One deliberate omission: `persistAssistantMessage` still calls `getChatTitle` on the abort path, so closing the tab on a first message costs one extra auxiliary call. Skipping it would leave the conversation untitled in the sidebar — happy to change it if reviewers prefer.