### PR TITLE
chore(docker): shrink build context and pruner install scope

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 node_modules/
 .next/
+.turbo/
 e2e
 docs
 devops

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,7 @@ on:
     workflows: ['Build'] # must match the name from `checks.yml`
     types: [completed]
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: docker-build-main
@@ -19,12 +20,15 @@ permissions:
 
 jobs:
   build_push_docker_images:
-    name: Build and push docker image ${{ matrix.image_name }}
+    name: Docker image ${{ matrix.image_name }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'main'
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
+    env:
+      is_dry_run: ${{ github.event_name == 'workflow_dispatch' }}
 
     strategy:
       matrix:
@@ -64,7 +68,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: ${{ env.is_dry_run == 'true' && 'Build (no push)' || 'Build and push' }}
         id: docker-build
         uses: docker/build-push-action@v7
         env:
@@ -88,12 +92,13 @@ jobs:
           tags: |
             ${{ matrix.image_ref }}:latest
             ${{ matrix.image_ref }}:${{ github.sha }}
-          push: true
+          push: ${{ env.is_dry_run != 'true' }}
           provenance: mode=max
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Generate artifact attestation
+        if: env.is_dry_run != 'true'
         uses: actions/attest@v4.2.2
         with:
           subject-name: ${{ matrix.image_ref }}

--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -12,22 +12,26 @@ FROM node:24.20.0-alpine AS base
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV TURBO_TELEMETRY_DISABLED=1
 
+FROM base AS builder-base
+ENV PNPM_STORE_DIR=/pnpm/store
+
 # Prune projects
-FROM base AS pruner
+FROM builder-base AS pruner
 WORKDIR /app
 
 COPY . .
 
 # setup pnpm and pnpm install in order to install turbo in the correct version
 RUN corepack enable && corepack prepare
-RUN pnpm install --frozen-lockfile --dev
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm install --filter . --frozen-lockfile --dev --prefer-offline
 
-ARG CI=true
+ARG CI
 RUN CI=${CI} \
     pnpm turbo prune ais-chat-admin --docker
 
 # Build the project
-FROM base AS builder
+FROM builder-base AS builder
 WORKDIR /app
 
 # Git is required for sentry
@@ -40,7 +44,8 @@ COPY --from=pruner /app/out/json/ .
 
 # First install the dependencies (as they change less often)
 RUN corepack enable && corepack prepare
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm install --frozen-lockfile --prefer-offline
 
 # Copy source code of isolated subworkspace
 COPY --from=pruner /app/out/full/ .
@@ -48,7 +53,7 @@ COPY --from=pruner /app/out/full/ .
 # Copy git history, required for sentry to determine release name
 COPY .git ./.git
 
-ARG CI=true
+ARG CI
 ARG APP_VERSION
 
 RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN,env=SENTRY_AUTH_TOKEN \

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -24,9 +24,9 @@ RUN corepack enable && corepack prepare
 # - any third‑party deps imported by those bundled packages (e.g. drizzle-orm) must be resolvable
 #   from the API's module resolution paths, i.e. /app/node_modules when running in the container
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
-    pnpm install --frozen-lockfile --dev --shamefully-hoist --prefer-offline
+    pnpm install --filter . --frozen-lockfile --dev --shamefully-hoist --prefer-offline
 
-ARG CI=true
+ARG CI
 RUN CI=${CI} \
     pnpm turbo prune ais-chat-api --docker
 
@@ -52,8 +52,7 @@ COPY --from=pruner /app/out/full/ .
 # Copy git history, required for sentry to determine release name
 COPY .git ./.git
 
-ARG CI=true
-
+ARG CI
 RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN,env=SENTRY_AUTH_TOKEN \
     --mount=type=secret,id=SENTRY_ORG,env=SENTRY_ORG \
     --mount=type=secret,id=SENTRY_PROJECT,env=SENTRY_PROJECT \

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -19,12 +19,8 @@ WORKDIR /app
 COPY . .
 # setup pnpm and pnpm install in order to install turbo in the correct version
 RUN corepack enable && corepack prepare
-# Use a hoisted node_modules layout so runtime resolution works with our build output:
-# - tsup bundles internal workspace packages (e.g. @ais-chat/*) into the API bundle
-# - any third‑party deps imported by those bundled packages (e.g. drizzle-orm) must be resolvable
-#   from the API's module resolution paths, i.e. /app/node_modules when running in the container
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
-    pnpm install --filter . --frozen-lockfile --dev --shamefully-hoist --prefer-offline
+    pnpm install --filter . --frozen-lockfile --dev --prefer-offline
 
 ARG CI
 RUN CI=${CI} \
@@ -43,6 +39,10 @@ COPY --from=pruner /app/out/json/ .
 
 # First install the dependencies (as they change less often)
 RUN corepack enable && corepack prepare
+# Use a hoisted node_modules layout so runtime resolution works with our build output:
+# - tsup bundles internal workspace packages (e.g. @ais-chat/*) into the API bundle
+# - any third‑party deps imported by those bundled packages (e.g. drizzle-orm) must be resolvable
+#   from the API's module resolution paths, i.e. /app/node_modules when running in the container
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
     pnpm install --frozen-lockfile --shamefully-hoist --prefer-offline
 

--- a/apps/chat-bot/Dockerfile
+++ b/apps/chat-bot/Dockerfile
@@ -12,22 +12,26 @@ FROM node:24.20.0-alpine AS base
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV TURBO_TELEMETRY_DISABLED=1
 
+FROM base AS builder-base
+ENV PNPM_STORE_DIR=/pnpm/store
+
 # Prune projects
-FROM base AS pruner
+FROM builder-base AS pruner
 WORKDIR /app
 
 COPY . .
 
 # setup pnpm and pnpm install in order to install turbo in the correct version
 RUN corepack enable && corepack prepare
-RUN pnpm install --frozen-lockfile --dev
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm install --filter . --frozen-lockfile --dev --prefer-offline
 
-ARG CI=true
+ARG CI
 RUN CI=${CI} \
     pnpm turbo prune ais-chat-app --docker
 
 # Build the project
-FROM base AS builder
+FROM builder-base AS builder
 WORKDIR /app
 
 # Git is required for sentry
@@ -40,7 +44,8 @@ COPY --from=pruner /app/out/json/ .
 
 # First install the dependencies (as they change less often)
 RUN corepack enable && corepack prepare
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm install --frozen-lockfile --prefer-offline
 
 # Copy source code of isolated subworkspace
 COPY --from=pruner /app/out/full/ .
@@ -48,7 +53,7 @@ COPY --from=pruner /app/out/full/ .
 # Copy git history, required for sentry to determine release name
 COPY .git ./.git
 
-ARG CI=true
+ARG CI
 ARG APP_VERSION
 
 RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN,env=SENTRY_AUTH_TOKEN \


### PR DESCRIPTION
- Add `builder-base` stage with `PNPM_STORE_DIR=/pnpm/store` shared by `pruner` and `builder` in admin/chat-bot Dockerfiles, paired with `--mount=type=cache,id=pnpm-store` for both install steps (matches the pattern already used in the api Dockerfile).
- Scope the pruner-stage install to `--filter .` (root only) since it only needs `turbo` to run `pnpm turbo prune` — avoids installing the full workspace before pruning.
- Drop redundant `ARG CI=true` defaults in later stages (the global `ARG CI=true` declared before the first `FROM` already provides the default).
- Add `.turbo/` to `.dockerignore` to keep local Turbo cache out of the build context.
- Add a `workflow_dispatch` trigger to the Docker Build workflow so it can be run manually against any branch, skipping the registry push/attestation (`is_dry_run` job env var) — used to verify these Dockerfile changes build successfully before merging.
- Align the api Dockerfile's pruner-stage install with admin/chat-bot: drop `--shamefully-hoist` (unnecessary for the root-only `--filter .` install) and its now-inapplicable explanatory comment.