### PR TITLE
fix: reject non-image files in scaled-image before image processing

### DIFF
--- a/apps/chat-bot/src/app/api/file-operations/scaled-image-service.test.ts
+++ b/apps/chat-bot/src/app/api/file-operations/scaled-image-service.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { NotFoundError } from '@shared/error';
+
+vi.mock('@shared/db/functions/files', () => ({
+  dbGetFilesInIds: vi.fn(),
+}));
+vi.mock('@shared/s3', () => ({
+  getFileFromS3: vi.fn(),
+}));
+
+import { dbGetFilesInIds } from '@shared/db/functions/files';
+import { getFileFromS3 } from '@shared/s3';
+import { createScaledImage } from './scaled-image-service';
+
+describe('createScaledImage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws NotFoundError when the file is not an image', async () => {
+    vi.mocked(dbGetFilesInIds).mockResolvedValue([{ id: 'file-1', type: 'pdf' }] as never);
+
+    await expect(createScaledImage({ fileId: 'file-1', width: 100, height: 100 })).rejects.toThrow(
+      NotFoundError,
+    );
+    expect(getFileFromS3).not.toHaveBeenCalled();
+  });
+
+  it('throws NotFoundError when the file does not exist', async () => {
+    vi.mocked(dbGetFilesInIds).mockResolvedValue([]);
+
+    await expect(createScaledImage({ fileId: 'file-1', width: 100, height: 100 })).rejects.toThrow(
+      NotFoundError,
+    );
+    expect(getFileFromS3).not.toHaveBeenCalled();
+  });
+});

--- a/apps/chat-bot/src/app/api/file-operations/scaled-image-service.ts
+++ b/apps/chat-bot/src/app/api/file-operations/scaled-image-service.ts
@@ -1,5 +1,8 @@
 import sharp from 'sharp';
 import { getFileFromS3 } from '@shared/s3';
+import { dbGetFilesInIds } from '@shared/db/functions/files';
+import { NotFoundError } from '@shared/error';
+import { isSupportedImageExtension } from '@/const';
 import { getImageContentType, streamToBuffer } from '@/utils/files/image-data';
 
 export async function createScaledImage({
@@ -11,6 +14,14 @@ export async function createScaledImage({
   width: number;
   height: number;
 }): Promise<{ buffer: Buffer; contentType: string }> {
+  const [file] = await dbGetFilesInIds([fileId]);
+  if (!file) {
+    throw new NotFoundError(`File not found: ${fileId}`);
+  }
+  if (!isSupportedImageExtension(file.type)) {
+    throw new NotFoundError(`File is not an image: ${fileId}`);
+  }
+
   const imageStream = await getFileFromS3(`message_attachments/${fileId}`);
   const imageBuffer = await streamToBuffer(imageStream);
   const image = sharp(imageBuffer);

--- a/apps/chat-bot/src/app/api/files/[fileId]/scaled-image/route.test.ts
+++ b/apps/chat-bot/src/app/api/files/[fileId]/scaled-image/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
+import { NotFoundError } from '@shared/error';
 
 vi.mock('@/auth/utils', () => ({
   getUser: vi.fn(),
@@ -65,5 +66,13 @@ describe('GET /api/files/[fileId]/scaled-image', () => {
 
     expect(response.status).toBe(403);
     expect(createScaledImage).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when createScaledImage reports the file is not an image', async () => {
+    vi.mocked(createScaledImage).mockRejectedValue(new NotFoundError('File is not an image'));
+
+    const response = await GET(buildRequest('?width=100&height=200'), { params });
+
+    expect(response.status).toBe(404);
   });
 });


### PR DESCRIPTION
The GET /api/files/[fileId]/scaled-image endpoint could be called with a
fileId pointing to a non-image file (e.g. a PDF), which was then fed into
sharp and failed during decoding.

createScaledImage now checks the file's stored type first and throws a
NotFoundError (mapped to 404) before reading from S3 or decoding, so
arbitrary files never reach the sharp image processor.

Tests: added service tests for the non-image and missing-file cases;
route test covers the 404 mapping.