### PR TITLE
TD-1550: Enable allow_all_providers, bump Bifrost to v2.1.1

### DIFF
--- a/devops/docker/bifrost/config.json
+++ b/devops/docker/bifrost/config.json
@@ -26,6 +26,7 @@
     },
     "virtual_keys": [
       {
+        "allow_all_providers": true,
         "id": "vk-all",
         "is_active": true,
         "name": "access to all providers",

--- a/devops/docker/docker-compose.local.yml
+++ b/devops/docker/docker-compose.local.yml
@@ -155,7 +155,7 @@ services:
         condition: service_healthy
 
   bifrost:
-    image: ghcr.io/maximhq/bifrost:v2.0.0
+    image: ghcr.io/maximhq/bifrost:v2.1.1
     restart: unless-stopped
     environment:
       BIFROST_ADMIN_USERNAME: admin

--- a/devops/docker/docker-compose.yml
+++ b/devops/docker/docker-compose.yml
@@ -154,7 +154,7 @@ services:
       start_period: 2s
 
   bifrost:
-    image: ghcr.io/maximhq/bifrost:v2.0.0
+    image: ghcr.io/maximhq/bifrost:v2.1.1
     restart: unless-stopped
     environment:
       BIFROST_ADMIN_USERNAME: admin


### PR DESCRIPTION
Bifrost v2.1.0 added `allow_all_providers`, which grants a virtual key access to every configured provider, including ones added later, without listing them in `provider_configs`.

- Enable `allow_all_providers: true` on the local virtual key in `devops/docker/bifrost/config.json`
- Bump the local Bifrost image to `v2.1.1` (required for the flag)