### PR TITLE
TD-1550: set bifrost source_of_truth to split

### DIFF
--- a/devops/docker/bifrost/config.json
+++ b/devops/docker/bifrost/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://www.getbifrost.ai/schema",
-  "source_of_truth": "config.json",
+  "source_of_truth": "split",
   "client": {
     "compat": {
       "convert_chat_to_responses": true,


### PR DESCRIPTION
- Change `source_of_truth` in `devops/docker/bifrost/config.json` from `config.json` to `split`
- Keeps config (whether changed manually or via the admin app) persisted in the DB across bifrost restarts
- Docs: https://docs.getbifrost.ai/deployment-guides/config-json/source-of-truth

🤖 Written by AI under human supervision.