### PR TITLE
fix: accept MIME-type file types in scaled-image guard

### DIFF
--- a/apps/chat-bot/src/app/api/file-operations/scaled-image-service.test.ts
+++ b/apps/chat-bot/src/app/api/file-operations/scaled-image-service.test.ts
@@ -34,4 +34,14 @@ describe('createScaledImage', () => {
     );
     expect(getFileFromS3).not.toHaveBeenCalled();
   });
+
+  it('accepts a file whose type is a MIME type and proceeds to fetch it', async () => {
+    vi.mocked(dbGetFilesInIds).mockResolvedValue([{ id: 'file-1', type: 'image/png' }] as never);
+    vi.mocked(getFileFromS3).mockRejectedValue(new Error('s3-reached'));
+
+    await expect(createScaledImage({ fileId: 'file-1', width: 100, height: 100 })).rejects.toThrow(
+      's3-reached',
+    );
+    expect(getFileFromS3).toHaveBeenCalledWith('message_attachments/file-1');
+  });
 });

--- a/apps/chat-bot/src/app/api/file-operations/scaled-image-service.ts
+++ b/apps/chat-bot/src/app/api/file-operations/scaled-image-service.ts
@@ -2,7 +2,6 @@ import sharp from 'sharp';
 import { getFileFromS3 } from '@shared/s3';
 import { dbGetFilesInIds } from '@shared/db/functions/files';
 import { NotFoundError } from '@shared/error';
-import { isSupportedImageExtension } from '@/const';
 import { getImageContentType, streamToBuffer } from '@/utils/files/image-data';
 
 export async function createScaledImage({
@@ -18,7 +17,7 @@ export async function createScaledImage({
   if (!file) {
     throw new NotFoundError(`File not found: ${fileId}`);
   }
-  if (!isSupportedImageExtension(file.type)) {
+  if (!getImageContentType(file.type).startsWith('image/')) {
     throw new NotFoundError(`File is not an image: ${fileId}`);
   }
 


### PR DESCRIPTION
The type column stores both extensions (png) and MIME types (image/png); the guard only checked extensions, so image/png files were wrongly 404'd. Now validated via getImageContentType, which handles both.